### PR TITLE
.mjs fix for taggedNode

### DIFF
--- a/change/@nova-react-38c687a3-505a-4ecc-bf08-660ac12cbdf7.json
+++ b/change/@nova-react-38c687a3-505a-4ecc-bf08-660ac12cbdf7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Fixes taggedNode to be compatible with .mjs; moves the @graphitation/graphql-js-tag as a peerDep rather than hard dep",
+  "packageName": "@nova/react",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/README.md
+++ b/packages/nova-react/README.md
@@ -3,3 +3,7 @@
 The Nova Facade is a set of interfaces that represent the core framework dependencies of a data-backed UI component in a large application. This allows high value components to be written in a host agnostic fashion and used within any host that implements the Nova contracts.
 
 This package provides a React specific implementation of the contexts etc required to make the host implementations accessible to the Nova component code, with the sister package @nova/types providing a framework agnostic set of contracts.
+
+## Prerequisites
+
+In order to use this package, make sure to add `@graphitation/graphql-js-tag` as a dependency in your `package.json` along side with `@nova/react`.

--- a/packages/nova-react/README.md
+++ b/packages/nova-react/README.md
@@ -6,4 +6,4 @@ This package provides a React specific implementation of the contexts etc requir
 
 ## Prerequisites
 
-In order to use this package, make sure to add `@graphitation/graphql-js-tag` as a dependency in your `package.json` along side with `@nova/react`.
+In order to use this package without compilation of documents, i.e. to parse string documents at runtime, make sure to add `@graphitation/graphql-js-tag` as a dependency in your `package.json` along side with `@nova/react`.

--- a/packages/nova-react/package.json
+++ b/packages/nova-react/package.json
@@ -14,10 +14,10 @@
     "nova-graphql-compiler": "./src/graphql/cli.js"
   },
   "peerDependencies": {
-    "react": "^16.13.0"
+    "react": "^16.13.0",
+    "@graphitation/graphql-js-tag": "^0.5.3"
   },
   "dependencies": {
-    "@graphitation/graphql-js-tag": "^0.5.3",
     "@nova/types": "^0.2.0",
     "graphql": "^15.5.0",
     "invariant": "^2.2.4",
@@ -26,6 +26,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
+    "@graphitation/graphql-js-tag": "^0.5.3",
     "@testing-library/react": "^12.0.0",
     "@types/invariant": "^2.2.35",
     "@types/jest": "^26.0.22",

--- a/packages/nova-react/src/graphql/taggedNode.ts
+++ b/packages/nova-react/src/graphql/taggedNode.ts
@@ -1,4 +1,11 @@
-import invariant from "invariant";
+/**
+ * Imports graphql-js-tag from a peer dependency.
+ * 
+ * @graphitation/graphql-js-tag is expected to be provided by the consumer using this library.
+ * Failure to do so will result in a TypeScript compilation or a bundling error - there is no
+ * need to incur runtime costs to run checks for this library as a dependency.
+ */
+import { graphql as graphqlJsTag } from "@graphitation/graphql-js-tag";
 
 /**
  * An opaque type used to annotate a GraphQL document.
@@ -43,13 +50,7 @@ export function graphql(
   document: TemplateStringsArray,
   ...fragments: GraphQLTaggedNode[]
 ): GraphQLTaggedNode {
-  const graphql: typeof import("@graphitation/graphql-js-tag").graphql =
-    require("@graphitation/graphql-js-tag").graphql;
-  invariant(
-    graphql !== undefined,
-    "Expected the host application to provide the `@graphitation/graphql-js-tag` package"
-  );
-  return graphql(
+  return graphqlJsTag(
     document,
     ...(fragments as any[])
   ) as unknown as GraphQLTaggedNode;


### PR DESCRIPTION
## Problem

`require` is not legal in ES modules. We can only use the `import` keyword

## What is changing in this PR

1. Replacing the "require" with a static import:
    ```js
    /**
     * Imports graphql-js-tag from a peer dependency.
     * 
     * @graphitation/graphql-js-tag is expected to be provided by the consumer using this library.
     * Failure to do so will result in a TypeScript compilation or a bundling error - there is no
     * need to incur runtime costs to run checks for this library as a dependency.
     */
    import { graphql as graphqlJsTag } from "@graphitation/graphql-js-tag";
    ```
2. Moves the `@graphitation/graphql-js-tag` as peerDep + devDep
3. Adds a little note in README.md about the pre-req
4. Removed the use of "invariant" to do checks for the dep