### PR TITLE
Add side effects false to all packages

### DIFF
--- a/change/@nova-react-8525508c-a4bb-4dad-90d1-6cb5f5147600.json
+++ b/change/@nova-react-8525508c-a4bb-4dad-90d1-6cb5f5147600.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added side effect flags to all package.json",
+  "packageName": "@nova/react",
+  "email": "mnovikov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-react-test-utils-8506f5a5-66a2-4800-9b23-2ddf8fbf0cc1.json
+++ b/change/@nova-react-test-utils-8506f5a5-66a2-4800-9b23-2ddf8fbf0cc1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added side effect flags to all package.json",
+  "packageName": "@nova/react-test-utils",
+  "email": "mnovikov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-types-d6a1e6e5-1188-47c6-82ed-17383f77a62d.json
+++ b/change/@nova-types-d6a1e6e5-1188-47c6-82ed-17383f77a62d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added side effect flags to all package.json",
+  "packageName": "@nova/types",
+  "email": "mnovikov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/package.json
+++ b/packages/nova-react-test-utils/package.json
@@ -41,6 +41,7 @@
     "types": "./lib/index.d.ts",
     "access": "public",
     "module": "./lib/index.mjs",
+    "sideEffects": false,
     "exports": {
       ".": {
         "import": "./lib/index.mjs",

--- a/packages/nova-react/package.json
+++ b/packages/nova-react/package.json
@@ -40,6 +40,7 @@
     "types": "./lib/index.d.ts",
     "access": "public",
     "module": "./lib/index.mjs",
+    "sideEffects": false,
     "exports": {
       ".": {
         "import": "./lib/index.mjs",

--- a/packages/nova-types/package.json
+++ b/packages/nova-types/package.json
@@ -18,6 +18,7 @@
     "types": "./lib/index.d.ts",
     "access": "public",
     "module": "./lib/index.mjs",
+    "sideEffects": false,
     "exports": {
       ".": {
         "import": "./lib/index.mjs",


### PR DESCRIPTION
Allows webpack to safely remove any unused exports by hinting that our modules do not implicitly perform any work solely by virtue of importing them.