### PR TITLE
Adding entity type for M365 message extensions.

### DIFF
--- a/change/@nova-types-7713dafb-2389-49fc-b04c-98e418485981.json
+++ b/change/@nova-types-7713dafb-2389-49fc-b04c-98e418485981.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adding message extension entity type.",
+  "packageName": "@nova/types",
+  "email": "82841113+megasly@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-types/src/nova-commanding-centralized.interface.ts
+++ b/packages/nova-types/src/nova-commanding-centralized.interface.ts
@@ -83,6 +83,7 @@ export enum EntityType {
   outlook_tasks = "outlook_tasks",
   m365_app = "m365_app",
   m365_appsideload = "m365_appsideload",
+  m365_messageextension = "m365_messageextension",
   office_home = "office_home",
   office_create = "office_create",
   office_mycontent = "office_mycontent",


### PR DESCRIPTION
We have one more entity type that needs to be added to get to parity support in office-start for message extensions.