### PR TITLE
Nova Eventing

### DIFF
--- a/change/@nova-react-cfc47f2c-d233-4792-8864-39974ea6995a.json
+++ b/change/@nova-react-cfc47f2c-d233-4792-8864-39974ea6995a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for Nova Eventing",
+  "packageName": "@nova/react",
+  "email": "kerrynb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-types-659bc505-b84d-40d3-a7a0-8f83c398423e.json
+++ b/change/@nova-types-659bc505-b84d-40d3-a7a0-8f83c398423e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for Nova Eventing",
+  "packageName": "@nova/types",
+  "email": "kerrynb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import {
+  NovaEventingProvider,
+  useNovaEventing,
+} from "./nova-eventing-provider";
+import {
+  NovaEventing,
+} from "@nova/types";
+
+describe(useNovaEventing, () => {
+  it("throws without a provider", () => {
+    expect.assertions(1);
+
+    const TestUndefinedContextComponent: React.FC = () => {
+      try {
+        useNovaEventing();
+      } catch (e) {
+        expect((e as Error).message).toMatch(
+          "Nova Eventing provider must be initialized prior to consumption!",
+        );
+      }
+      return null;
+    };
+
+    render(<TestUndefinedContextComponent />);
+  });
+
+  it("exposes the provided implementation, and calls the provided mapper", () => {
+    expect.assertions(2);
+
+    const eventing = {
+      bubble: jest.fn(),
+    } as unknown as NovaEventing;
+
+    const mapper = jest.fn();
+
+    const mockEvent: React.SyntheticEvent = {
+      target: {} as EventTarget,
+      timeStamp: 123,
+      type: "keydown",
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      nativeEvent: {} as Event,
+      currentTarget: {} as EventTarget & Element,
+      bubbles: false,
+      cancelable: false,
+      defaultPrevented: false,
+      eventPhase: 0,
+      isTrusted: false,
+      isDefaultPrevented: jest.fn(),
+      isPropagationStopped: jest.fn(),
+      persist:  jest.fn()
+    };
+
+
+    const TestPassedContextComponent: React.FC = () => {
+      const facadeFromContext = useNovaEventing();
+      facadeFromContext.bubble({ event: { originator: "test", type: "test"}, reactEvent: mockEvent });
+      expect(eventing.bubble).toBeCalledTimes(1);
+      expect(mapper).toBeCalledTimes(1);
+      return null;
+    };
+
+    render(
+      <NovaEventingProvider eventing={eventing} reactEventMapper={mapper}>
+        <TestPassedContextComponent />
+      </NovaEventingProvider>,
+    );
+  });
+});

--- a/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
@@ -8,9 +8,7 @@ import {
   NovaEventingProvider,
   useNovaEventing,
 } from "./nova-eventing-provider";
-import {
-  NovaEventing,
-} from "@nova/types";
+import { NovaEventing } from "@nova/types";
 
 describe(useNovaEventing, () => {
   it("throws without a provider", () => {
@@ -54,13 +52,15 @@ describe(useNovaEventing, () => {
       isTrusted: false,
       isDefaultPrevented: jest.fn(),
       isPropagationStopped: jest.fn(),
-      persist:  jest.fn()
+      persist: jest.fn(),
     };
-
 
     const TestPassedContextComponent: React.FC = () => {
       const facadeFromContext = useNovaEventing();
-      facadeFromContext.bubble({ event: { originator: "test", type: "test"}, reactEvent: mockEvent });
+      facadeFromContext.bubble({
+        event: { originator: "test", type: "test" },
+        reactEvent: mockEvent,
+      });
       expect(eventing.bubble).toBeCalledTimes(1);
       expect(mapper).toBeCalledTimes(1);
       return null;

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import {
+  NovaEvent,
+  NovaEventing,
+  EventWrapper
+} from "@nova/types";
+import { mapEventMetadata } from "./react-event-source-mapper";
+import invariant from "invariant";
+
+// Initializing default with null to make sure providers are correctly placed in the tree
+const NovaEventingContext = React.createContext<NovaReactEventing | null>(null);
+
+interface NovaEventingProviderProps {
+  eventing: NovaEventing;
+  reactEventMapper: (reactEventWrapper: ReactEventWrapper) => EventWrapper;
+}
+
+export interface ReactEventWrapper {
+    event: NovaEvent<unknown>; // The event details for handling
+    reactEvent: React.SyntheticEvent;
+  }
+
+export interface NovaReactEventing {
+  bubble(event: ReactEventWrapper): Promise<void>;
+}
+
+export const NovaEventingProvider: React.FunctionComponent<NovaEventingProviderProps> = ({
+  children,
+  eventing,
+  reactEventMapper,
+}) => {
+    
+  // Stabilize the context value to prevent retriggering all consumers whenever this component rerenders
+  const reactEventing: NovaReactEventing = React.useMemo(() => ({
+    bubble: (eventWrapper: ReactEventWrapper) => {
+      const mappedEvent = reactEventMapper
+        ? reactEventMapper(eventWrapper)
+        : mapEventMetadata(eventWrapper);
+      return eventing.bubble(mappedEvent);
+    },
+  }), [eventing, reactEventMapper]);
+
+  return (
+    <NovaEventingContext.Provider value={reactEventing}>
+      {children}
+    </NovaEventingContext.Provider>
+  );
+};
+NovaEventingProvider.displayName = "NovaEventingProvider";
+
+export const useNovaEventing = (): NovaReactEventing => {
+  const eventing = React.useContext<NovaReactEventing | null>(
+    NovaEventingContext
+  );
+  invariant(
+    eventing,
+    "Nova Eventing provider must be initialized prior to consumption!"
+  );
+  return eventing;
+};

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -1,9 +1,5 @@
 import * as React from "react";
-import {
-  NovaEvent,
-  NovaEventing,
-  EventWrapper
-} from "@nova/types";
+import { NovaEvent, NovaEventing, EventWrapper } from "@nova/types";
 import { mapEventMetadata } from "./react-event-source-mapper";
 import invariant from "invariant";
 
@@ -16,45 +12,44 @@ interface NovaEventingProviderProps {
 }
 
 export interface ReactEventWrapper {
-    event: NovaEvent<unknown>; // The event details for handling
-    reactEvent: React.SyntheticEvent;
-  }
+  event: NovaEvent<unknown>; // The event details for handling
+  reactEvent: React.SyntheticEvent;
+}
 
 export interface NovaReactEventing {
   bubble(event: ReactEventWrapper): Promise<void>;
 }
 
-export const NovaEventingProvider: React.FunctionComponent<NovaEventingProviderProps> = ({
-  children,
-  eventing,
-  reactEventMapper,
-}) => {
-    
-  // Stabilize the context value to prevent retriggering all consumers whenever this component rerenders
-  const reactEventing: NovaReactEventing = React.useMemo(() => ({
-    bubble: (eventWrapper: ReactEventWrapper) => {
-      const mappedEvent = reactEventMapper
-        ? reactEventMapper(eventWrapper)
-        : mapEventMetadata(eventWrapper);
-      return eventing.bubble(mappedEvent);
-    },
-  }), [eventing, reactEventMapper]);
+export const NovaEventingProvider: React.FunctionComponent<NovaEventingProviderProps> =
+  ({ children, eventing, reactEventMapper }) => {
+    // Stabilize the context value to prevent retriggering all consumers whenever this component rerenders
+    const reactEventing: NovaReactEventing = React.useMemo(
+      () => ({
+        bubble: (eventWrapper: ReactEventWrapper) => {
+          const mappedEvent = reactEventMapper
+            ? reactEventMapper(eventWrapper)
+            : mapEventMetadata(eventWrapper);
+          return eventing.bubble(mappedEvent);
+        },
+      }),
+      [eventing, reactEventMapper],
+    );
 
-  return (
-    <NovaEventingContext.Provider value={reactEventing}>
-      {children}
-    </NovaEventingContext.Provider>
-  );
-};
+    return (
+      <NovaEventingContext.Provider value={reactEventing}>
+        {children}
+      </NovaEventingContext.Provider>
+    );
+  };
 NovaEventingProvider.displayName = "NovaEventingProvider";
 
 export const useNovaEventing = (): NovaReactEventing => {
   const eventing = React.useContext<NovaReactEventing | null>(
-    NovaEventingContext
+    NovaEventingContext,
   );
   invariant(
     eventing,
-    "Nova Eventing provider must be initialized prior to consumption!"
+    "Nova Eventing provider must be initialized prior to consumption!",
   );
   return eventing;
 };

--- a/packages/nova-react/src/eventing/react-event-source-mapper.test.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { mapEventMetadata } from "./react-event-source-mapper";
+import { NovaEvent, InputType } from "@nova/types";
+
+const mappedTypes = [
+  ["dblclick", InputType.mouse],
+  ["keydown", InputType.keyboard],
+  ["keyup", InputType.keyboard],
+  ["keypress", InputType.keyboard],
+  ["mousedown", InputType.mouse],
+  ["mouseenter", InputType.mouse],
+  ["mouseleave", InputType.mouse],
+  ["mousemove", InputType.mouse],
+  ["mouseover", InputType.mouse],
+  ["mouseout", InputType.mouse],
+  ["mouseup", InputType.mouse],
+  ["touchcancel", InputType.touch],
+  ["touchend", InputType.touch],
+  ["touchmove", InputType.touch],
+  ["touchstart", InputType.touch],
+  ["wheel", InputType.mouse],
+  ["scroll", InputType.unknown],
+  ["input", InputType.unknown],
+  ["submit", InputType.unknown],
+  ["toggle", InputType.unknown],
+];
+
+const mappedPointerTypes = [
+  ["", InputType.keyboard],
+  ["mouse", InputType.mouse],
+  ["pen", InputType.pen],
+  ["touch", InputType.touch],
+  ["newUnknown", InputType.unknown],
+];
+
+const novaEventWithData: NovaEvent<string> = {
+  data: jest.fn(),
+  originator: "testOrigin",
+  type: "testType",
+};
+
+const mockEvent: React.SyntheticEvent = {
+  target: {} as EventTarget,
+  timeStamp: 123,
+  type: "keydown",
+  preventDefault: jest.fn(),
+  stopPropagation: jest.fn(),
+  nativeEvent: {} as Event,
+  currentTarget: {} as EventTarget & Element,
+  bubbles: false,
+  cancelable: false,
+  defaultPrevented: false,
+  eventPhase: 0,
+  isTrusted: false,
+  isDefaultPrevented: jest.fn(),
+  isPropagationStopped: jest.fn(),
+  persist: jest.fn(),
+};
+
+describe(mapEventMetadata, () => {
+  test.each(mappedTypes)(
+    "Validate React events with type `%s` maps to expected Nova input type",
+    (eventType: string, novaInputType: string) => {
+      mockEvent.type = eventType;
+      const mappedEventWrapper = mapEventMetadata({
+        reactEvent: mockEvent,
+        event: novaEventWithData,
+      });
+      // Assert that the current theme maps correctly to the Converged theme
+      expect(mappedEventWrapper.source.inputType).toEqual(novaInputType);
+      expect(mappedEventWrapper.source.timeStamp).toEqual(mockEvent.timeStamp);
+      expect(mappedEventWrapper.event).toEqual(novaEventWithData);
+    },
+  );
+
+  test.each(mappedPointerTypes)(
+    "Validate React Pointer events with type `%s` maps to correct Nova input type",
+    (eventType: string, novaInputType: string) => {
+      mockEvent.type = "click";
+      mockEvent.nativeEvent = {
+        pointerType: eventType,
+      } as unknown as Event;
+      const mappedEventWrapper = mapEventMetadata({
+        reactEvent: mockEvent,
+        event: novaEventWithData,
+      });
+      // Assert that the current theme maps correctly to the Converged theme
+      expect(mappedEventWrapper.source.inputType).toEqual(novaInputType);
+      expect(mappedEventWrapper.source.timeStamp).toEqual(mockEvent.timeStamp);
+      expect(mappedEventWrapper.event).toEqual(novaEventWithData);
+    },
+  );
+});

--- a/packages/nova-react/src/eventing/react-event-source-mapper.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.ts
@@ -1,0 +1,85 @@
+import { EventWrapper, InputType, Source } from "@nova/types";
+import { ReactEventWrapper } from "./nova-eventing-provider";
+
+/**
+ * Maps DOM event type strings to the Nova InputType.
+ *
+ * Initial implementation is not exhaustive and should be
+ * extended as new requirements arise.
+ *
+ * Note following excluded event types that could be considered:
+ * scroll, input, submit, toggle
+ */
+const typeMap = {
+  dblclick: InputType.mouse,
+  keydown: InputType.keyboard,
+  keyup: InputType.keyboard,
+  keypress: InputType.keyboard,
+  mousedown: InputType.mouse,
+  mouseenter: InputType.mouse,
+  mouseleave: InputType.mouse,
+  mousemove: InputType.mouse,
+  mouseover: InputType.mouse,
+  mouseout: InputType.mouse,
+  mouseup: InputType.mouse,
+  touchcancel: InputType.touch,
+  touchend: InputType.touch,
+  touchmove: InputType.touch,
+  touchstart: InputType.touch,
+  wheel: InputType.mouse,
+};
+
+/**
+ * Maps PointerEvent pointerTypes to Nova InputType.
+ *
+ * Initial implementation assumes all "" pointer types
+ * come from keyboard triggered events using enter/space.
+ *
+ * If other input sources are discovered to also trigger
+ * PointerEvents with "" type, this will need to be revised.
+ */
+const pointerTypeMap = {
+  "": InputType.keyboard,
+  mouse: InputType.mouse,
+  pen: InputType.pen,
+  touch: InputType.touch,
+};
+
+/**
+ * Uses the pointer type map to decide the Nova input type.
+ * Returns unknown if the map doesn't match.
+ * @param pointerType type string from DOM pointer event
+ * @returns Nova input type
+ */
+const mapPointerTypeEvents = (pointerType: string): keyof typeof InputType => {
+  const inputType = pointerTypeMap[pointerType as keyof typeof pointerTypeMap];
+  return inputType ?? InputType.unknown;
+};
+
+/**
+ * Extracts the React specific event information and maps it into
+ * the framework agnostic Nova event format.
+ * @param eventWrapper The input event for mapping
+ * @returns The mapped event
+ */
+export const mapEventMetadata = (eventWrapper: ReactEventWrapper<unknown>) => {
+  const { event, reactEvent } = eventWrapper;
+  const inputType =
+    reactEvent.type === "click"
+      ? mapPointerTypeEvents(
+          (reactEvent as React.PointerEvent).nativeEvent.pointerType,
+        )
+      : typeMap[reactEvent.type as keyof typeof typeMap];
+
+  const source: Source = {
+    inputType: inputType ?? InputType.unknown,
+    timeStamp: reactEvent.timeStamp,
+  };
+
+  const mappedEvent: EventWrapper<unknown> = {
+    event,
+    source,
+  };
+
+  return mappedEvent;
+};

--- a/packages/nova-react/src/eventing/react-event-source-mapper.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.ts
@@ -62,7 +62,7 @@ const mapPointerTypeEvents = (pointerType: string): keyof typeof InputType => {
  * @param eventWrapper The input event for mapping
  * @returns The mapped event
  */
-export const mapEventMetadata = (eventWrapper: ReactEventWrapper<unknown>) => {
+export const mapEventMetadata = (eventWrapper: ReactEventWrapper) => {
   const { event, reactEvent } = eventWrapper;
   const inputType =
     reactEvent.type === "click"
@@ -76,7 +76,7 @@ export const mapEventMetadata = (eventWrapper: ReactEventWrapper<unknown>) => {
     timeStamp: reactEvent.timeStamp,
   };
 
-  const mappedEvent: EventWrapper<unknown> = {
+  const mappedEvent: EventWrapper = {
     event,
     source,
   };

--- a/packages/nova-react/src/index.ts
+++ b/packages/nova-react/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./commanding/nova-centralized-commanding-provider";
+export * from "./eventing/nova-eventing-provider";
+export * from "./eventing/react-event-source-mapper";
 export * from "./graphql/hooks";
 export * from "./graphql/nova-graphql-provider";
 export * from "./graphql/taggedNode";

--- a/packages/nova-types/src/index.ts
+++ b/packages/nova-types/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./nova-commanding-centralized.interface";
 export * from "./nova-graphql.interface";
+export * from "./nova-eventing.interface";

--- a/packages/nova-types/src/nova-eventing.interface.ts
+++ b/packages/nova-types/src/nova-eventing.interface.ts
@@ -1,0 +1,28 @@
+export interface NovaEventing {
+  bubble(event: EventWrapper): Promise<void>;
+}
+
+export interface EventWrapper {
+  event: NovaEvent<unknown>; // The event details for handling
+  source: Source; // Details about the underlying event
+}
+
+export interface NovaEvent<T> {
+  originator: string; // eg AppBar - matches to the Views root element for the control
+  type: string; // eg AppTileClick - control will have multiple groups of events
+  data?: () => T; // Optional function to generate the data associated with the event
+}
+
+export interface Source {
+  timeStamp: number; // When the event occured
+  inputType: keyof typeof InputType;
+}
+
+export const InputType = {
+  unknown: "unknown", // Fallback for events triggered by the user from an unknown input
+  mouse: "mouse",
+  keyboard: "keyboard",
+  touch: "touch",
+  pen: "pen",
+  programmatic: "programmatic", // Used for events triggered by code processes
+} as const;

--- a/packages/nova-types/src/nova-eventing.interface.ts
+++ b/packages/nova-types/src/nova-eventing.interface.ts
@@ -18,6 +18,13 @@ export interface Source {
   inputType: keyof typeof InputType;
 }
 
+/**
+ * InputType is the UI framework agnostic list of detectable input types.
+ * This list should be extended as additional input types are created.
+ * Note: at this point in time there is no reliable way to detect screen readers.
+ * They are detected as either mouse or keyboard depending in the reader's interaction
+ * mode.
+ */
 export const InputType = {
   unknown: "unknown", // Fallback for events triggered by the user from an unknown input
   mouse: "mouse",


### PR DESCRIPTION
Nova Eventing is designed to replace Nova Centralized Commanding as the preferred method of communication from Nova UI components.

Unlike commanding, which couples the UI components to the knowledge of who they are communicating with, eventing allows the components to define their own event shapes, which handlers in the higher business logic layers can interpret and respond to as needed.