### PR TITLE
Meet app: Adding Meet app in supported entity list

### DIFF
--- a/change/@nova-types-feb1beb5-7855-4232-878b-68e26e113dca.json
+++ b/change/@nova-types-feb1beb5-7855-4232-878b-68e26e113dca.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adding Meet app in supported Entity type",
+  "packageName": "@nova/types",
+  "email": "ajakum@AJAKUM-1",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-types/src/nova-commanding-centralized.interface.ts
+++ b/packages/nova-types/src/nova-commanding-centralized.interface.ts
@@ -76,6 +76,7 @@ export enum EntityType {
   teams_calendar = "teams_calendar",
   teams_calling = "teams_calling",
   teams_search = "teams_search",
+  teams_meet = "teams_meet",
   outlook_mail = "outlook_mail",
   outlook_calendar = "outlook_calendar",
   outlook_people = "outlook_people",


### PR DESCRIPTION
Meet app is new experience which we going to show in left of Teams App.
In this PR, adding Meet app in supported Entity type