### PR TITLE
Add exports for commanding types

### DIFF
--- a/change/@nova-types-2034fe2e-819c-4040-bd83-260d3c18e008.json
+++ b/change/@nova-types-2034fe2e-819c-4040-bd83-260d3c18e008.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export the commanding types",
+  "packageName": "@nova/types",
+  "email": "kerrynb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-types/src/index.ts
+++ b/packages/nova-types/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./nova-commanding.interface";
 export * from "./nova-commanding-centralized.interface";
 export * from "./nova-graphql.interface";
 export * from "./nova-eventing.interface";


### PR DESCRIPTION
Exports were missing for the new commanding types, fixing that.