### PR TITLE
Stabilize Eventing across function changes

### DIFF
--- a/change/@nova-react-41a33ffb-b7b9-480a-9302-6346b4128802.json
+++ b/change/@nova-react-41a33ffb-b7b9-480a-9302-6346b4128802.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Stabilize eventing across function changes",
+  "packageName": "@nova/react",
+  "email": "kerrynb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
@@ -8,11 +8,56 @@ import {
   GeneratedEventWrapper,
   NovaEventingProvider,
   ReactEventWrapper,
+  NovaReactEventing,
   useNovaEventing,
 } from "./nova-eventing-provider";
 import { EventWrapper, InputType, NovaEventing } from "@nova/types";
 
-describe(useNovaEventing, () => {
+import * as ReactEventSourceMapper from "./react-event-source-mapper";
+
+jest.mock("./react-event-source-mapper");
+
+describe("useNovaEventing", () => {
+  let TestComponent: React.FunctionComponent<any>;
+  let eventing: NovaEventing;
+  let prevWrappedEventing: NovaReactEventing;
+  let eventCallback: () => void;
+  const initialChildren = "initial children";
+  const updatedChildren = "updated children";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const mapEventMetadataSpy = jest.spyOn(
+      ReactEventSourceMapper,
+      "mapEventMetadata",
+    );
+
+    eventing = { bubble: jest.fn() };
+    prevWrappedEventing = undefined as unknown as NovaReactEventing;
+
+    TestComponent = ({ childrenText }) => {
+      const wrappedEventing: NovaReactEventing = useNovaEventing();
+      expect(wrappedEventing).toBeDefined();
+      expect(wrappedEventing).not.toBe(eventing);
+      if (prevWrappedEventing) {
+        expect(prevWrappedEventing).toBe(wrappedEventing);
+      }
+      prevWrappedEventing = wrappedEventing;
+
+      const eventWrapper = {} as ReactEventWrapper;
+      wrappedEventing.bubble(eventWrapper);
+      expect(mapEventMetadataSpy).toHaveBeenCalledWith(eventWrapper);
+      expect(eventing.bubble).toHaveBeenCalled();
+
+      eventCallback = () => {
+        wrappedEventing.bubble(eventWrapper);
+      };
+
+      return <div data-testid="children">{childrenText}</div>;
+    };
+  });
+
   it("throws without a provider", () => {
     expect.assertions(1);
 
@@ -30,7 +75,143 @@ describe(useNovaEventing, () => {
     render(<TestUndefinedContextComponent />);
   });
 
-  it("exposes 'bubble', which calls the React event mapper and bubble functions", () => {
+  test("Takes in children and eventing props, renders children, and updates children as expected.", () => {
+    const wrapper = render(
+      <NovaEventingProvider
+        children={<TestComponent childrenText={initialChildren} />}
+        eventing={eventing}
+        reactEventMapper={ReactEventSourceMapper.mapEventMetadata}
+      />,
+    );
+    expect(wrapper.queryAllByTestId("children")[0].innerHTML).toBe(
+      initialChildren,
+    );
+
+    wrapper.rerender(
+      <NovaEventingProvider
+        children={<TestComponent childrenText={updatedChildren} />}
+        eventing={eventing}
+        reactEventMapper={ReactEventSourceMapper.mapEventMetadata}
+      />,
+    );
+    expect(wrapper.queryAllByTestId("children")[0].innerHTML).toBe(
+      updatedChildren,
+    );
+  });
+
+  test("Takes in children and eventing props, creates a stable wrapped NovaReactEventing instance from eventing across re-renders when children do not change.", () => {
+    const stableTestComponentInstance = (
+      <TestComponent childrenText={initialChildren} />
+    );
+
+    const wrapper = render(
+      <NovaEventingProvider
+        children={stableTestComponentInstance}
+        eventing={eventing}
+        reactEventMapper={ReactEventSourceMapper.mapEventMetadata}
+      />,
+    );
+    expect(wrapper.queryAllByTestId("children")[0].innerHTML).toBe(
+      initialChildren,
+    );
+
+    wrapper.rerender(
+      <NovaEventingProvider
+        children={stableTestComponentInstance}
+        eventing={eventing}
+        reactEventMapper={ReactEventSourceMapper.mapEventMetadata}
+      />,
+    );
+    expect(wrapper.queryAllByTestId("children")[0].innerHTML).toBe(
+      initialChildren,
+    );
+
+    // Update eventing instance to test useRef pathway. This will ensure the wrapped eventing instance
+    // returned from useEventing is stable from one render to the next.
+    const newEventing = { bubble: jest.fn() };
+
+    wrapper.rerender(
+      <NovaEventingProvider
+        children={stableTestComponentInstance}
+        eventing={newEventing}
+        reactEventMapper={ReactEventSourceMapper.mapEventMetadata}
+      />,
+    );
+
+    expect(wrapper.queryAllByTestId("children")[0].innerHTML).toBe(
+      initialChildren,
+    );
+
+    //Trigger a callback on the test child through eventing
+    eventCallback();
+
+    expect(newEventing.bubble).toHaveBeenCalled();
+
+    // Update mapper instance to test useRef pathway. This will ensure the wrapped eventing instance
+    // returned from useEventing is stable from one render to the next.
+    const newMapper: (reactEventWrapper: ReactEventWrapper) => EventWrapper =
+      jest.fn();
+
+    wrapper.rerender(
+      <NovaEventingProvider
+        children={stableTestComponentInstance}
+        eventing={newEventing}
+        reactEventMapper={newMapper}
+      />,
+    );
+
+    expect(wrapper.queryAllByTestId("children")[0].innerHTML).toBe(
+      initialChildren,
+    );
+
+    //Trigger a callback on the test child through eventing
+    eventCallback();
+
+    expect(newMapper).toHaveBeenCalled();
+  });
+});
+
+describe("NovaReactEventing exposes 'generateEvent'", () => {
+  interface Props {
+    overrideTimestamp?: boolean;
+    expectedTime: number;
+    eventing: NovaEventing;
+    mapper: (reactEventWrapper: ReactEventWrapper) => EventWrapper;
+  }
+  const TestPassedContextComponent: React.FC<Props> = (
+    props: Props,
+  ): React.ReactElement | null => {
+    const { eventing, mapper, overrideTimestamp, expectedTime } = props;
+    const facadeFromContext = useNovaEventing();
+    const event = { originator: "test", type: "test" };
+
+    let eventWrapper: GeneratedEventWrapper;
+
+    if (overrideTimestamp) {
+      eventWrapper = {
+        event,
+        timeStampOverride: expectedTime,
+      };
+    } else {
+      eventWrapper = {
+        event,
+      };
+    }
+
+    facadeFromContext.generateEvent(eventWrapper);
+
+    expect(eventing.bubble).toBeCalledWith({
+      event,
+      source: {
+        inputType: InputType.programmatic,
+        timeStamp: expectedTime,
+      },
+    });
+    expect(mapper).toBeCalledTimes(0);
+    return null;
+  };
+
+  it("and defaults to Date.now for event timestamp and calls the bubble function.", () => {
     expect.assertions(2);
 
     const eventing = {
@@ -39,126 +220,40 @@ describe(useNovaEventing, () => {
 
     const mapper = jest.fn();
 
-    const mockEvent: React.SyntheticEvent = {
-      target: {} as EventTarget,
-      timeStamp: 123,
-      type: "keydown",
-      preventDefault: jest.fn(),
-      stopPropagation: jest.fn(),
-      nativeEvent: {} as Event,
-      currentTarget: {} as EventTarget & Element,
-      bubbles: false,
-      cancelable: false,
-      defaultPrevented: false,
-      eventPhase: 0,
-      isTrusted: false,
-      isDefaultPrevented: jest.fn(),
-      isPropagationStopped: jest.fn(),
-      persist: jest.fn(),
-    };
-
-    const TestPassedContextComponent: React.FC = () => {
-      const facadeFromContext = useNovaEventing();
-      facadeFromContext.bubble({
-        event: { originator: "test", type: "test" },
-        reactEvent: mockEvent,
-      });
-      expect(eventing.bubble).toBeCalledTimes(1);
-      expect(mapper).toBeCalledTimes(1);
-      return null;
-    };
+    const now = 1000;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
 
     render(
       <NovaEventingProvider eventing={eventing} reactEventMapper={mapper}>
-        <TestPassedContextComponent />
+        <TestPassedContextComponent
+          expectedTime={now}
+          eventing={eventing}
+          mapper={mapper}
+        />
       </NovaEventingProvider>,
     );
   });
 
-  describe("exposes 'generateEvent'", () => {
-    interface Props {
-      overrideTimestamp?: boolean;
-      expectedTime: number;
-      eventing: NovaEventing;
-      mapper: (reactEventWrapper: ReactEventWrapper) => EventWrapper;
-    }
-    const TestPassedContextComponent: React.FC<Props> = (
-      props: Props,
-    ): React.ReactElement | null => {
-      const { eventing, mapper, overrideTimestamp, expectedTime } = props;
-      const facadeFromContext = useNovaEventing();
-      const event = { originator: "test", type: "test" };
+  it("and takes an override to set the timestamp and calls the bubble function.", () => {
+    expect.assertions(2);
 
-      let eventWrapper: GeneratedEventWrapper;
+    const eventing = {
+      bubble: jest.fn(),
+    } as unknown as NovaEventing;
 
-      if (overrideTimestamp) {
-        eventWrapper = {
-          event,
-          timeStampOverride: expectedTime,
-        };
-      } else {
-        eventWrapper = {
-          event,
-        };
-      }
+    const mapper = jest.fn();
 
-      facadeFromContext.generateEvent(eventWrapper);
+    const overrideTime = 9999999999;
 
-      expect(eventing.bubble).toBeCalledWith({
-        event,
-        source: {
-          inputType: InputType.programmatic,
-          timeStamp: expectedTime,
-        },
-      });
-      expect(mapper).toBeCalledTimes(0);
-      return null;
-    };
-
-    it("and defaults to Date.now for event timestamp and calls the bubble function.", () => {
-      expect.assertions(2);
-
-      const eventing = {
-        bubble: jest.fn(),
-      } as unknown as NovaEventing;
-
-      const mapper = jest.fn();
-
-      const now = 1000;
-      jest.spyOn(Date, "now").mockImplementation(() => now);
-
-      render(
-        <NovaEventingProvider eventing={eventing} reactEventMapper={mapper}>
-          <TestPassedContextComponent
-            expectedTime={now}
-            eventing={eventing}
-            mapper={mapper}
-          />
-        </NovaEventingProvider>,
-      );
-    });
-
-    it("and takes an override to set the timestamp and calls the bubble function.", () => {
-      expect.assertions(2);
-
-      const eventing = {
-        bubble: jest.fn(),
-      } as unknown as NovaEventing;
-
-      const mapper = jest.fn();
-
-      const overrideTime = 9999999999;
-
-      render(
-        <NovaEventingProvider eventing={eventing} reactEventMapper={mapper}>
-          <TestPassedContextComponent
-            overrideTimestamp
-            expectedTime={overrideTime}
-            eventing={eventing}
-            mapper={mapper}
-          />
-        </NovaEventingProvider>,
-      );
-    });
+    render(
+      <NovaEventingProvider eventing={eventing} reactEventMapper={mapper}>
+        <TestPassedContextComponent
+          overrideTimestamp
+          expectedTime={overrideTime}
+          eventing={eventing}
+          mapper={mapper}
+        />
+      </NovaEventingProvider>,
+    );
   });
 });


### PR DESCRIPTION
Looking at scenarios in Teams, the host applications may need to change the functions they are using to bubble events with.

This change encapsulates the current callback functions within refs, and prevents cascading rerenders to the children of the NovaEventing provider should these functions change.