### PR TITLE
feat(nova-react-test-utils): add eventing mock to nova test environment

### DIFF
--- a/change/@nova-react-test-utils-a107f215-b954-4488-8be4-52db5d40134e.json
+++ b/change/@nova-react-test-utils-a107f215-b954-4488-8be4-52db5d40134e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "allow mocking eventing on test environment",
+  "packageName": "@nova/react-test-utils",
+  "email": "sjwilczynski@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/src/nova-mock-environment.tsx
+++ b/packages/nova-react-test-utils/src/nova-mock-environment.tsx
@@ -1,16 +1,19 @@
 import React from "react";
 import type { ComponentType } from "react";
-import { NovaCentralizedCommanding, NovaGraphQL } from "@nova/types";
+import { NovaCentralizedCommanding, NovaGraphQL, NovaEventing } from "@nova/types";
 import { MockFunctions } from "@graphitation/apollo-mock-client";
 
 import {
   GraphQLTaggedNode,
+  mapEventMetadata,
   NovaCentralizedCommandingProvider,
+  NovaEventingProvider,
   NovaGraphQLProvider,
 } from "@nova/react";
 
 export interface NovaMockEnvironment {
   commanding: jest.Mocked<NovaCentralizedCommanding>;
+  eventing: jest.Mocked<NovaEventing>;
   graphql: NovaGraphQL & { mock: MockFunctions<unknown, GraphQLTaggedNode> };
   /**
    * A React component that will be used to wrap the NovaFacadeProvider children. This is used by the test-utils to
@@ -26,15 +29,17 @@ interface NovaMockEnvironmentProviderProps {
 export const NovaMockEnvironmentProvider: React.FunctionComponent<NovaMockEnvironmentProviderProps> =
   ({ children, environment }) => {
     return (
-      <NovaCentralizedCommandingProvider commanding={environment.commanding}>
-        <NovaGraphQLProvider graphql={environment.graphql}>
-          {React.createElement(
-            environment.providerWrapper,
-            undefined,
-            children,
-          )}
-        </NovaGraphQLProvider>
-      </NovaCentralizedCommandingProvider>
+      <NovaEventingProvider eventing={environment.eventing} reactEventMapper={mapEventMetadata}>
+        <NovaCentralizedCommandingProvider commanding={environment.commanding}>
+          <NovaGraphQLProvider graphql={environment.graphql}>
+            {React.createElement(
+              environment.providerWrapper,
+              undefined,
+              children,
+            )}
+          </NovaGraphQLProvider>
+        </NovaCentralizedCommandingProvider>
+      </NovaEventingProvider>
     );
   };
 NovaMockEnvironmentProvider.displayName = "NovaMockEnvironmentProvider";

--- a/packages/nova-react-test-utils/src/nova-mock-environment.tsx
+++ b/packages/nova-react-test-utils/src/nova-mock-environment.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import type { ComponentType } from "react";
-import { NovaCentralizedCommanding, NovaGraphQL, NovaEventing } from "@nova/types";
+import {
+  NovaCentralizedCommanding,
+  NovaGraphQL,
+  NovaEventing,
+} from "@nova/types";
 import { MockFunctions } from "@graphitation/apollo-mock-client";
 
 import {
@@ -29,7 +33,10 @@ interface NovaMockEnvironmentProviderProps {
 export const NovaMockEnvironmentProvider: React.FunctionComponent<NovaMockEnvironmentProviderProps> =
   ({ children, environment }) => {
     return (
-      <NovaEventingProvider eventing={environment.eventing} reactEventMapper={mapEventMetadata}>
+      <NovaEventingProvider
+        eventing={environment.eventing}
+        reactEventMapper={mapEventMetadata}
+      >
         <NovaCentralizedCommandingProvider commanding={environment.commanding}>
           <NovaGraphQLProvider graphql={environment.graphql}>
             {React.createElement(

--- a/packages/nova-react-test-utils/src/test-utils.test.tsx
+++ b/packages/nova-react-test-utils/src/test-utils.test.tsx
@@ -5,7 +5,7 @@ import {
   create as createTestRenderer,
   ReactTestRenderer,
 } from "react-test-renderer";
-import { EntityCommand } from "@nova/types";
+import { EntityCommand, EventWrapper } from "@nova/types";
 
 import { graphql, useLazyLoadQuery } from "@nova/react";
 
@@ -82,6 +82,12 @@ describe(_createMockEnvironmentWithSchema, () => {
       const cmd = {} as EntityCommand;
       environment.commanding.trigger(cmd);
       expect(environment.commanding.trigger.mock.calls).toEqual([[cmd]]);
+    });
+
+    it("exposes mocks for eventing", () => {
+      const event = {} as EventWrapper;
+      environment.eventing.bubble(event);
+      expect(environment.eventing.bubble.mock.calls).toEqual([[event]]);
     });
 
     it("exposes mocks for GraphQL operations", async () => {

--- a/packages/nova-react-test-utils/src/test-utils.tsx
+++ b/packages/nova-react-test-utils/src/test-utils.tsx
@@ -44,6 +44,9 @@ export function _createMockEnvironmentWithSchema(
     commanding: {
       trigger: jest.fn(),
     },
+    eventing: {
+      bubble: jest.fn(),
+    },
     graphql: {
       ...(GraphQLHooks as NovaGraphQL),
       mock: client.mock as MockFunctions<any, any>,


### PR DESCRIPTION
As commanding is obsolete, for completeness it would be nice to mock nova eventing on the test environment. This PR adds the mentioned basic eventing mock to allow consumers of the package to make assertions on it.