### PR TITLE
Fix Source timeStamp to consistently use Epoch time

### DIFF
--- a/change/@nova-react-30a04f5f-7bd3-4681-8961-7b6e6de5a434.json
+++ b/change/@nova-react-30a04f5f-7bd3-4681-8961-7b6e6de5a434.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Source timestamp to use consistent Epoch time",
+  "packageName": "@nova/react",
+  "email": "kerryn@zyridium.net",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-types-1d16fa1d-4ada-4265-ab2f-9ec90486cfb1.json
+++ b/change/@nova-types-1d16fa1d-4ada-4265-ab2f-9ec90486cfb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update comments on interfaces",
+  "packageName": "@nova/types",
+  "email": "kerryn@zyridium.net",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/eventing/react-event-source-mapper.test.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.test.ts
@@ -2,9 +2,12 @@
  * @jest-environment jsdom
  */
 
-import React from "react";
+import React, { SyntheticEvent } from "react";
 import { mapEventMetadata } from "./react-event-source-mapper";
 import { NovaEvent, InputType } from "@nova/types";
+
+const nowTimeStamp = 1670638671187;
+Date.now = jest.fn(() => nowTimeStamp);
 
 const mappedTypes = [
   ["dblclick", InputType.mouse],
@@ -43,13 +46,22 @@ const novaEventWithData: NovaEvent<string> = {
   type: "testType",
 };
 
-const mockEvent: React.SyntheticEvent = {
+const timeStamp = 123;
+const timeOrigin = 1670638671187;
+
+const mockUIEvent: React.SyntheticEvent = {
   target: {} as EventTarget,
-  timeStamp: 123,
+  timeStamp,
   type: "keydown",
   preventDefault: jest.fn(),
   stopPropagation: jest.fn(),
-  nativeEvent: {} as Event,
+  nativeEvent: {
+    view: {
+      performance: {
+        timeOrigin,
+      },
+    },
+  } as unknown as UIEvent,
   currentTarget: {} as EventTarget & Element,
   bubbles: false,
   cancelable: false,
@@ -65,14 +77,16 @@ describe(mapEventMetadata, () => {
   test.each(mappedTypes)(
     "Validate React events with type `%s` maps to expected Nova input type",
     (eventType: string, novaInputType: string) => {
-      mockEvent.type = eventType;
+      mockUIEvent.type = eventType;
       const mappedEventWrapper = mapEventMetadata({
-        reactEvent: mockEvent,
+        reactEvent: mockUIEvent,
         event: novaEventWithData,
       });
-      // Assert that the current theme maps correctly to the Converged theme
+
       expect(mappedEventWrapper.source.inputType).toEqual(novaInputType);
-      expect(mappedEventWrapper.source.timeStamp).toEqual(mockEvent.timeStamp);
+      expect(mappedEventWrapper.source.timeStamp).toEqual(
+        timeStamp + timeOrigin,
+      );
       expect(mappedEventWrapper.event).toEqual(novaEventWithData);
     },
   );
@@ -80,18 +94,34 @@ describe(mapEventMetadata, () => {
   test.each(mappedPointerTypes)(
     "Validate React Pointer events with type `%s` maps to correct Nova input type",
     (eventType: string, novaInputType: string) => {
-      mockEvent.type = "click";
-      mockEvent.nativeEvent = {
+      mockUIEvent.type = "click";
+      mockUIEvent.nativeEvent = {
         pointerType: eventType,
-      } as unknown as Event;
+        view: {
+          performance: {
+            timeOrigin,
+          },
+        },
+      } as unknown as UIEvent;
       const mappedEventWrapper = mapEventMetadata({
-        reactEvent: mockEvent,
+        reactEvent: mockUIEvent,
         event: novaEventWithData,
       });
-      // Assert that the current theme maps correctly to the Converged theme
+
       expect(mappedEventWrapper.source.inputType).toEqual(novaInputType);
-      expect(mappedEventWrapper.source.timeStamp).toEqual(mockEvent.timeStamp);
+      expect(mappedEventWrapper.source.timeStamp).toEqual(
+        timeStamp + timeOrigin,
+      );
       expect(mappedEventWrapper.event).toEqual(novaEventWithData);
     },
   );
+
+  test("Validate non UI events (no view data) use Date.now for the timestamp", () => {
+    const mappedEventWrapper = mapEventMetadata({
+      reactEvent: { type: "unknown" } as SyntheticEvent,
+      event: novaEventWithData,
+    });
+
+    expect(mappedEventWrapper.source.timeStamp).toEqual(nowTimeStamp);
+  });
 });

--- a/packages/nova-react/src/eventing/react-event-source-mapper.test.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.test.ts
@@ -82,7 +82,7 @@ describe(mapEventMetadata, () => {
         reactEvent: mockUIEvent,
         event: novaEventWithData,
       });
-
+      // Assert that the inputType maps correctly to the expected Nova inputType
       expect(mappedEventWrapper.source.inputType).toEqual(novaInputType);
       expect(mappedEventWrapper.source.timeStamp).toEqual(
         timeStamp + timeOrigin,
@@ -107,7 +107,7 @@ describe(mapEventMetadata, () => {
         reactEvent: mockUIEvent,
         event: novaEventWithData,
       });
-
+      // Assert that the inputType maps correctly to the expected Nova inputType
       expect(mappedEventWrapper.source.inputType).toEqual(novaInputType);
       expect(mappedEventWrapper.source.timeStamp).toEqual(
         timeStamp + timeOrigin,

--- a/packages/nova-react/src/eventing/react-event-source-mapper.test.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.test.ts
@@ -124,4 +124,22 @@ describe(mapEventMetadata, () => {
 
     expect(mappedEventWrapper.source.timeStamp).toEqual(nowTimeStamp);
   });
+
+  test("Validate events without a timestamp fallback to Date.now for the timestamp", () => {
+    const mappedEventWrapper = mapEventMetadata({
+      reactEvent: {
+        type: "unknown",
+        nativeEvent: {
+          view: {
+            performance: {
+              timeOrigin,
+            },
+          },
+        },
+      } as unknown as SyntheticEvent,
+      event: novaEventWithData,
+    });
+
+    expect(mappedEventWrapper.source.timeStamp).toEqual(nowTimeStamp);
+  });
 });

--- a/packages/nova-react/src/eventing/react-event-source-mapper.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { EventWrapper, InputType, Source } from "@nova/types";
 import { ReactEventWrapper } from "./nova-eventing-provider";
 
@@ -71,9 +72,20 @@ export const mapEventMetadata = (eventWrapper: ReactEventWrapper) => {
         )
       : typeMap[reactEvent.type as keyof typeof typeMap];
 
+  // Timestamps in DOM events are relative to the window origin time
+  // Nova event timestamps should be Epoch timestamps
+  // If the event doesn't have a timestamp, fall back to Date.now()
+  let timeStamp: number;
+  const uiEvent = reactEvent.nativeEvent as UIEvent;
+  if (uiEvent.view) {
+    timeStamp = uiEvent.view.performance.timeOrigin + reactEvent.timeStamp;
+  } else {
+    timeStamp = Date.now();
+  }
+
   const source: Source = {
     inputType: inputType ?? InputType.unknown,
-    timeStamp: reactEvent.timeStamp,
+    timeStamp,
   };
 
   const mappedEvent: EventWrapper = {

--- a/packages/nova-react/src/eventing/react-event-source-mapper.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.ts
@@ -77,7 +77,7 @@ export const mapEventMetadata = (eventWrapper: ReactEventWrapper) => {
   // If the event doesn't have a timestamp, fall back to Date.now()
   let timeStamp: number;
   const uiEvent = reactEvent.nativeEvent as UIEvent;
-  if (uiEvent.view) {
+  if (uiEvent?.view && reactEvent.timeStamp) {
     timeStamp = uiEvent.view.performance.timeOrigin + reactEvent.timeStamp;
   } else {
     timeStamp = Date.now();

--- a/packages/nova-react/src/eventing/react-event-source-mapper.ts
+++ b/packages/nova-react/src/eventing/react-event-source-mapper.ts
@@ -74,7 +74,8 @@ export const mapEventMetadata = (eventWrapper: ReactEventWrapper) => {
 
   // Timestamps in DOM events are relative to the window origin time
   // Nova event timestamps should be Epoch timestamps
-  // If the event doesn't have a timestamp, fall back to Date.now()
+  // If the underlying timeOrigin isn't accessible or the timestamp
+  // is missing, fall back to Date.now()
   let timeStamp: number;
   const uiEvent = reactEvent.nativeEvent as UIEvent;
   if (uiEvent?.view && reactEvent.timeStamp) {

--- a/packages/nova-types/src/nova-eventing.interface.ts
+++ b/packages/nova-types/src/nova-eventing.interface.ts
@@ -28,29 +28,31 @@ export interface NovaEvent<T> {
    */
   originator: string;
   /**
-   * The Event type is unique within the originator to specify the nature
-   * of the event. Each originator will likely support multiple groups of events.
+   * The Event type is a unique string within an originator that specifies the nature
+   * of the event. Each originator will likely support multiple types of events.
    * e.g. AppTileClick
    */
   type: string;
   /**
    * The optional Event data function allows the originator to encode typed data
-   * with the event. This can be used for functional or telemetry purposes.
+   * with the event. This can be used for functional purposes, or in combination
+   * with the Source object for telemetry purposes.
    */
   data?: () => T;
 }
 
 /**
  * The Source object contains the information about the user interaction
- * used to generate the Event. For Nova Eventing in React, it is automatically
+ * that generated the Event. For Nova Eventing in React, it is automatically
  * derived from the React SyntheticEvent.
  * Additional metadata will be added here as required by event managers.
  */
 export interface Source {
   /**
-   * Timestamp a number in Epoch format (milliseconds since 1 Jan 1970)
-   * If not able to be extracted from the React event, the event source mapper
-   * should use Date.now() at the point of bubbling.
+   * Timestamp is a number in Epoch format (milliseconds since 1 Jan 1970).
+   * For Nova Eventing in React, if not able to be extracted from the React
+   * event, the event source mapper should set it to Date.now() at the point
+   * of bubbling.
    */
   timeStamp: number;
   /**

--- a/packages/nova-types/src/nova-eventing.interface.ts
+++ b/packages/nova-types/src/nova-eventing.interface.ts
@@ -22,7 +22,7 @@ export interface EventWrapper {
 
 export interface NovaEvent<T> {
   /**
-   * The Event originator is a unique string identifier the component 
+   * The Event originator is a unique string identifier the component
    * that is sending the event.
    * e.g. AppBar
    */

--- a/packages/nova-types/src/nova-eventing.interface.ts
+++ b/packages/nova-types/src/nova-eventing.interface.ts
@@ -10,14 +10,34 @@ export interface NovaEventing {
 }
 
 export interface EventWrapper {
-  event: NovaEvent<unknown>; // The event details for handling
-  source: Source; // Details about the underlying event
+  /**
+   * The event details for handling
+   */
+  event: NovaEvent<unknown>;
+  /**
+   * Details about the originating event like input method and timestamp
+   */
+  source: Source;
 }
 
 export interface NovaEvent<T> {
-  originator: string; // eg AppBar - matches to the Views root element for the control
-  type: string; // eg AppTileClick - control will have multiple groups of events
-  data?: () => T; // Optional function to generate the data associated with the event
+  /**
+   * The Event originator is a unique string identifier the component 
+   * that is sending the event.
+   * e.g. AppBar
+   */
+  originator: string;
+  /**
+   * The Event type is unique within the originator to specify the nature
+   * of the event. Each originator will likely support multiple groups of events.
+   * e.g. AppTileClick
+   */
+  type: string;
+  /**
+   * The optional Event data function allows the originator to encode typed data
+   * with the event. This can be used for functional or telemetry purposes.
+   */
+  data?: () => T;
 }
 
 /**
@@ -27,7 +47,19 @@ export interface NovaEvent<T> {
  * Additional metadata will be added here as required by event managers.
  */
 export interface Source {
-  timeStamp: number; // When the event occured
+  /**
+   * Timestamp a number in Epoch format (milliseconds since 1 Jan 1970)
+   * If not able to be extracted from the React event, the event source mapper
+   * should use Date.now() at the point of bubbling.
+   */
+  timeStamp: number;
+  /**
+   * InputType is the UI framework agnostic list of detectable input types.
+   * This list should be extended as additional input types are created.
+   * Note: at this point in time there is no reliable way to detect screen readers.
+   * They are detected as either mouse or keyboard depending in the reader's interaction
+   * mode.
+   */
   inputType: keyof typeof InputType;
 }
 
@@ -39,10 +71,16 @@ export interface Source {
  * mode.
  */
 export const InputType = {
-  unknown: "unknown", // Fallback for events triggered by the user from an unknown input
+  /**
+   * Fallback for events triggered by the user from an unknown input
+   */
+  unknown: "unknown",
   mouse: "mouse",
   keyboard: "keyboard",
   touch: "touch",
   pen: "pen",
-  programmatic: "programmatic", // Used for events triggered by code processes
+  /**
+   * Used for events triggered by code processes
+   */
+  programmatic: "programmatic",
 } as const;


### PR DESCRIPTION
React SyntheticEvent timestamps are based on the DOM event timeStamps that are derived as 'time since document load'. (https://developer.mozilla.org/en-US/docs/Web/API/Event/timeStamp).

The timeStamp field on the Nova Source object is expected to use the Javascript Epoch time format (milliseconds since Jan 1 1970).

This change uses the underlying event data attached to the React SyntheticEvent to convert the UIEvent timeStamp into standard Epoch format, and falls back to Date.now() if the data is not available.