### PR TITLE
Add `teams_people` EntityType to Nova Types

### DIFF
--- a/change/@nova-types-430aed2d-bfd4-4391-a8c8-5bb7621c429e.json
+++ b/change/@nova-types-430aed2d-bfd4-4391-a8c8-5bb7621c429e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated nova types to include teams_people Entity type",
+  "packageName": "@nova/types",
+  "email": "mushierc@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-types/src/nova-commanding-centralized.interface.ts
+++ b/packages/nova-types/src/nova-commanding-centralized.interface.ts
@@ -77,6 +77,7 @@ export enum EntityType {
   teams_calling = "teams_calling",
   teams_search = "teams_search",
   teams_meet = "teams_meet",
+  teams_people = "teams_people",
   outlook_mail = "outlook_mail",
   outlook_calendar = "outlook_calendar",
   outlook_people = "outlook_people",


### PR DESCRIPTION
As we are looking at integrating People Experience into Teams, we need the `EntityType` to represent this integration in the commanding.