### PR TITLE
breaking(nova-react-test-utils): remove dependency on Teams schema

### DIFF
--- a/change/@nova-react-test-utils-4384258e-c0ad-46fc-9e2c-9451950fc9b9.json
+++ b/change/@nova-react-test-utils-4384258e-c0ad-46fc-9e2c-9451950fc9b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "remove dependency on teams schema",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/src/test-utils.test.tsx
+++ b/packages/nova-react-test-utils/src/test-utils.test.tsx
@@ -10,7 +10,7 @@ import { EntityCommand, EventWrapper } from "@nova/types";
 import { graphql, useLazyLoadQuery } from "@nova/react";
 
 import {
-  _createMockEnvironmentWithSchema,
+  createMockEnvironment,
   MockPayloadGenerator,
   getOperationName,
   getOperationType,
@@ -56,11 +56,11 @@ const QuerySubject: React.FC = () => {
   return data ? <span>{data.user.name}</span> : null;
 };
 
-describe(_createMockEnvironmentWithSchema, () => {
+describe(createMockEnvironment, () => {
   let environment: NovaMockEnvironment;
 
   beforeEach(() => {
-    environment = _createMockEnvironmentWithSchema(schema);
+    environment = createMockEnvironment(schema);
   });
 
   it("wraps the user specified children in an Apollo provider", () => {


### PR DESCRIPTION
Fixes #8. It's a breaking change but a needed one. When bumping version in TMP we will have to pass the schema manually