### PR TITLE
Update package.json files with exports.types and repository entries

### DIFF
--- a/change/@nova-react-2f32fdc6-3d91-4ef6-a1cc-c230cf674e55.json
+++ b/change/@nova-react-2f32fdc6-3d91-4ef6-a1cc-c230cf674e55.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add types entry to exports map",
+  "packageName": "@nova/react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-react-test-utils-f39ce6bd-4d0d-41eb-a9ed-493bc7576cf5.json
+++ b/change/@nova-react-test-utils-f39ce6bd-4d0d-41eb-a9ed-493bc7576cf5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add types entry to exports map",
+  "packageName": "@nova/react-test-utils",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-types-fac25c58-df02-45ee-9ba9-8463b9694634.json
+++ b/change/@nova-types-fac25c58-df02-45ee-9ba9-8463b9694634.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add types entry to exports map",
+  "packageName": "@nova/types",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/package.json
+++ b/packages/nova-react-test-utils/package.json
@@ -44,6 +44,7 @@
     "module": "./lib/index.mjs",
     "exports": {
       ".": {
+        "types": "./lib/index.d.ts",
         "import": "./lib/index.mjs",
         "require": "./lib/index.js"
       }

--- a/packages/nova-react-test-utils/package.json
+++ b/packages/nova-react-test-utils/package.json
@@ -36,6 +36,11 @@
     "react": "^17.0.2",
     "react-test-renderer": "^17.0.2"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/nova-facade.git",
+    "directory": "packages/nova-test-utils"
+  },
   "sideEffects": false,
   "access": "public",
   "publishConfig": {

--- a/packages/nova-react/package.json
+++ b/packages/nova-react/package.json
@@ -37,6 +37,11 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/nova-facade.git",
+    "directory": "packages/nova-react"
+  },
   "sideEffects": false,
   "access": "public",
   "publishConfig": {

--- a/packages/nova-react/package.json
+++ b/packages/nova-react/package.json
@@ -45,6 +45,7 @@
     "module": "./lib/index.mjs",
     "exports": {
       ".": {
+        "types": "./lib/index.d.ts",
         "import": "./lib/index.mjs",
         "require": "./lib/index.js"
       }

--- a/packages/nova-types/package.json
+++ b/packages/nova-types/package.json
@@ -21,6 +21,7 @@
     "module": "./lib/index.mjs",
     "exports": {
       ".": {
+        "types": "./lib/index.d.ts",
         "import": "./lib/index.mjs",
         "require": "./lib/index.js"
       }

--- a/packages/nova-types/package.json
+++ b/packages/nova-types/package.json
@@ -13,6 +13,11 @@
     "@types/jest": "^26.0.22",
     "monorepo-scripts": "*"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/nova-facade.git",
+    "directory": "packages/nova-types"
+  },
   "sideEffects": false,
   "access": "public",
   "publishConfig": {


### PR DESCRIPTION
When building with strict mode with Typescript 5.0 using [`resolvePackageJsonExports`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#resolvepackagejsonexports), Typescript will ignore the root `types` field and look for `types` in the `exports` entry being imported. If it's not present, then no type information is imported, and it will throw if `strict` mode is enabled.

The simple fix here is to mirror the root `types` field in `exports["."].types`.

Additionally, I added links to this repository in the `package.json`, as I had to ask around to find the repository.