### PR TITLE
Update nova hooks to support context

### DIFF
--- a/change/@nova-react-aefe8057-bbfd-45da-97e9-8fe424c4acaf.json
+++ b/change/@nova-react-aefe8057-bbfd-45da-97e9-8fe424c4acaf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update nova hooks to support context",
+  "packageName": "@nova/react",
+  "email": "52814187+ira-kaundal@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-types-127764de-3d1d-4990-b7db-862910f13cba.json
+++ b/change/@nova-types-127764de-3d1d-4990-b7db-862910f13cba.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update nova hooks to support context",
+  "packageName": "@nova/types",
+  "email": "52814187+ira-kaundal@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/graphql/hooks.test.tsx
+++ b/packages/nova-react/src/graphql/hooks.test.tsx
@@ -47,7 +47,8 @@ describe(useLazyLoadQuery, () => {
       const { data } = useLazyLoadQuery<{
         response: string;
         variables: Record<string, unknown>;
-      }>(query, {});
+        context?: Record<string, unknown>;
+      }>(query, {}, { context: { callerInfo: "subject-with-query" } });
       return <span>{data}</span>;
     };
 
@@ -57,7 +58,11 @@ describe(useLazyLoadQuery, () => {
       </NovaGraphQLProvider>,
     );
 
-    expect(graphql.useLazyLoadQuery).toHaveBeenCalledWith(query, {}, undefined);
+    expect(graphql.useLazyLoadQuery).toHaveBeenCalledWith(
+      query,
+      {},
+      { context: { callerInfo: "subject-with-query" } }
+    );
     expect(screen.getByText("some-data")).toBeDefined();
   });
 });
@@ -163,6 +168,7 @@ describe(useSubscription, () => {
     const expectedArgument = {
       subscription,
       variables: { someVar: "some-value" },
+      context: { callerInfo: "subject-with-subscription" },
       onNext,
       onError,
     };

--- a/packages/nova-react/src/graphql/hooks.ts
+++ b/packages/nova-react/src/graphql/hooks.ts
@@ -47,12 +47,14 @@ import type { KeyType, KeyTypeData, OperationType } from "./types";
  * @param variables Object containing the variable values to fetch the query. These variables need to match GraphQL
  *                  variables declared inside the query.
  * @param options Options passed on to the underlying implementation.
+ * @param options.context The query context to pass along the apollo link chain. Should be avoided when possible as
+ *                        it will not be compatible with Relay APIs.
  * @returns An object with either an error, the result data, or neither while loading.
  */
 export function useLazyLoadQuery<TQuery extends OperationType>(
   query: GraphQLTaggedNode,
   variables: TQuery["variables"],
-  options?: { fetchPolicy: "cache-first" },
+  options?: { fetchPolicy?: "cache-first"; context?: TQuery["context"] }
 ): { error?: Error; data?: TQuery["response"] } {
   const graphql = useNovaGraphQL();
   invariant(
@@ -126,8 +128,7 @@ export function useLazyLoadQuery<TQuery extends OperationType>(
  *                    fragment.
  * @returns The data corresponding to the field selections.
  */
-export function useFragment<TKey extends KeyType>(
-  fragmentInput: GraphQLTaggedNode,
+export function useFragment<TKey extends KeyType>(fragmentInput: GraphQLTaggedNode,
   fragmentRef: TKey,
 ): KeyTypeData<TKey> {
   return (
@@ -141,6 +142,10 @@ interface GraphQLSubscriptionConfig<
 > {
   subscription: GraphQLTaggedNode;
   variables: TSubscriptionPayload["variables"];
+  /**
+   * Should be avoided when possible as it will not be compatible with Relay APIs.
+   */
+  context: TSubscriptionPayload["context"];
   /**
    * Should response be nullable?
    */
@@ -161,6 +166,10 @@ export function useSubscription<TSubscriptionPayload extends OperationType>(
 
 interface MutationCommitterOptions<TMutationPayload extends OperationType> {
   variables: TMutationPayload["variables"];
+  /**
+   * Should be avoided when possible as it will not be compatible with Relay APIs.
+   */
+  context?: TMutationPayload["context"];
   optimisticResponse?: Partial<TMutationPayload["response"]> | null;
 }
 

--- a/packages/nova-react/src/graphql/hooks.ts
+++ b/packages/nova-react/src/graphql/hooks.ts
@@ -128,7 +128,8 @@ export function useLazyLoadQuery<TQuery extends OperationType>(
  *                    fragment.
  * @returns The data corresponding to the field selections.
  */
-export function useFragment<TKey extends KeyType>(fragmentInput: GraphQLTaggedNode,
+export function useFragment<TKey extends KeyType>(
+  fragmentInput: GraphQLTaggedNode,
   fragmentRef: TKey,
 ): KeyTypeData<TKey> {
   return (

--- a/packages/nova-react/src/graphql/types.ts
+++ b/packages/nova-react/src/graphql/types.ts
@@ -2,8 +2,13 @@ export interface Variables {
   [name: string]: any;
 }
 
+export interface Context {
+  [name: string]: any
+}
+
 export interface OperationType {
   readonly variables: Variables;
+  readonly context?: Context;
   readonly response: unknown;
   readonly rawResponse?: unknown;
 }

--- a/packages/nova-types/src/nova-graphql.interface.ts
+++ b/packages/nova-types/src/nova-graphql.interface.ts
@@ -25,6 +25,7 @@ export interface NovaGraphQL<GraphQLDocument = any> {
   useSubscription?: (config: {
     subscription: GraphQLDocument;
     variables: { [name: string]: unknown };
+    context?: { [name: string]: unknown };
     onNext?: (response: unknown) => void;
     onError?: (error: Error) => void;
   }) => void;
@@ -34,6 +35,7 @@ export interface NovaGraphQL<GraphQLDocument = any> {
   ) => [
     (options: {
       variables: { [name: string]: unknown };
+      context?: { [name: string]: unknown };
       optimisticResponse?: unknown | null;
     }) => Promise<{ errors?: readonly Error[]; data?: unknown }>,
     boolean,


### PR DESCRIPTION
Follow up from PR in duct-tape: https://github.com/microsoft/graphitation/pull/297

This PR updates hooks to support the passing of context.