### PR TITLE
Make context optional in use subscription

### DIFF
--- a/change/@nova-react-b4586a9b-4aa7-4cfa-8a5c-81fe8d19a33f.json
+++ b/change/@nova-react-b4586a9b-4aa7-4cfa-8a5c-81fe8d19a33f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make context optional in use subscription",
+  "packageName": "@nova/react",
+  "email": "52814187+ira-kaundal@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/graphql/hooks.ts
+++ b/packages/nova-react/src/graphql/hooks.ts
@@ -146,7 +146,7 @@ interface GraphQLSubscriptionConfig<
   /**
    * Should be avoided when possible as it will not be compatible with Relay APIs.
    */
-  context: TSubscriptionPayload["context"];
+  context?: TSubscriptionPayload["context"];
   /**
    * Should response be nullable?
    */


### PR DESCRIPTION
Small fix to make context an optional parameter in useSubscription hook