### PR TITLE
Add unmountEventing through the NovaEventingProvider

### DIFF
--- a/change/@nova-react-2a92f71d-e096-4da8-afb5-d02dd26f4bc9.json
+++ b/change/@nova-react-2a92f71d-e096-4da8-afb5-d02dd26f4bc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add useNovaUnmountEventing",
+  "packageName": "@nova/react",
+  "email": "dratkins@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -75,12 +75,12 @@ export const NovaEventingProvider: React.FunctionComponent<
     mapperRef.current = reactEventMapper;
   }
 
-  const reactEventing: NovaReactEventing = React.useMemo(
+  const reactEventing = React.useMemo(
     generateEventing(eventingRef, mapperRef),
     [],
   );
 
-  const reactUnmountEventing: NovaReactEventing = React.useMemo(
+  const reactUnmountEventing = React.useMemo(
     generateEventing(unmountEventingRef, mapperRef),
     [],
   );
@@ -120,7 +120,7 @@ const generateEventing =
       (reactEventWrapper: ReactEventWrapper) => EventWrapper
     >,
   ) =>
-  () => ({
+  (): NovaReactEventing => ({
     bubble: (eventWrapper: ReactEventWrapper) => {
       const mappedEvent: EventWrapper = mapperRef.current(eventWrapper);
       return eventingRef.current.bubble(mappedEvent);

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -3,9 +3,10 @@ import type { NovaEvent, NovaEventing, EventWrapper } from "@nova/types";
 import { InputType } from "@nova/types";
 import invariant from "invariant";
 
-// Initializing default with null to make sure providers are correctly placed in the tree
+// Context is initialized with an empty object and this is null-checked within the hooks
 const NovaEventingContext = React.createContext<INovaEventingContext>({});
 
+// Both are optional in the context for initialization state only, but eventing must be supplied in the props
 interface INovaEventingContext {
   eventing?: NovaReactEventing;
   unmountEventing?: NovaReactEventing;
@@ -104,6 +105,12 @@ export const useNovaEventing = (): NovaReactEventing => {
   return eventing;
 };
 
+/**
+ * Used for eventing that should be triggered when the component is unmounted, such as within a useEffect cleanup function
+ * If unmountEventing has not been supplied to the NovaEventingProvider, this will fallback to use the defualt eventing instance
+ *
+ * @returns NovaReactEventing
+ */
 export const useNovaUnmountEventing = (): NovaReactEventing => {
   const { unmountEventing } = React.useContext(NovaEventingContext);
   invariant(

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -4,10 +4,16 @@ import { InputType } from "@nova/types";
 import invariant from "invariant";
 
 // Initializing default with null to make sure providers are correctly placed in the tree
-const NovaEventingContext = React.createContext<NovaReactEventing | null>(null);
+const NovaEventingContext = React.createContext<INovaEventingContext>({});
+
+interface INovaEventingContext {
+  eventing?: NovaReactEventing;
+  unmountEventing?: NovaReactEventing;
+}
 
 interface NovaEventingProviderProps {
   eventing: NovaEventing;
+  unmountEventing?: NovaEventing; // Optional version of eventing to use when unmounting, defaults to eventing if not supplied
   /**
    * Mapping logic to transform a React SyntheticEvent into a Nova
    * Source object. Supply the Nova default implemenation using the import
@@ -47,57 +53,86 @@ export interface NovaReactEventing {
   generateEvent(eventWrapper: GeneratedEventWrapper): Promise<void>;
 }
 
-export const NovaEventingProvider: React.FunctionComponent<NovaEventingProviderProps> =
-  ({ children, eventing, reactEventMapper }) => {
-    // Nova contexts provide a facade over framework functions
-    // We don't need to trigger rerender in children when we are rerendered
-    // or when the input functions change, we just need to make sure callbacks
-    // use the right functions
-    const eventingRef = React.useRef(eventing);
-    if (eventingRef.current !== eventing) {
-      eventingRef.current = eventing;
-    }
+export const NovaEventingProvider: React.FunctionComponent<
+  NovaEventingProviderProps
+> = ({ children, eventing, unmountEventing, reactEventMapper }) => {
+  // Nova contexts provide a facade over framework functions
+  // We don't need to trigger rerender in children when we are rerendered
+  // or when the input functions change, we just need to make sure callbacks
+  // use the right functions
+  const eventingRef = React.useRef(eventing);
+  if (eventingRef.current !== eventing) {
+    eventingRef.current = eventing;
+  }
 
-    const mapperRef = React.useRef(reactEventMapper);
-    if (mapperRef.current !== reactEventMapper) {
-      mapperRef.current = reactEventMapper;
-    }
+  const unmountEventingRef = React.useRef(unmountEventing || eventing);
+  if (unmountEventingRef.current !== unmountEventing) {
+    unmountEventingRef.current = unmountEventing || eventing; // default to eventing if unmountEventing not supplied
+  }
 
-    const reactEventing: NovaReactEventing = React.useMemo(
-      () => ({
-        bubble: (eventWrapper: ReactEventWrapper) => {
-          const mappedEvent: EventWrapper = mapperRef.current(eventWrapper);
-          return eventingRef.current.bubble(mappedEvent);
-        },
-        generateEvent: (eventWrapper: GeneratedEventWrapper) => {
-          const mappedEvent = {
-            event: eventWrapper.event,
-            source: {
-              inputType: InputType.programmatic,
-              timeStamp: eventWrapper.timeStampOverride ?? Date.now(),
-            },
-          };
-          return eventingRef.current.bubble(mappedEvent);
-        },
-      }),
-      [],
-    );
+  const mapperRef = React.useRef(reactEventMapper);
+  if (mapperRef.current !== reactEventMapper) {
+    mapperRef.current = reactEventMapper;
+  }
 
-    return (
-      <NovaEventingContext.Provider value={reactEventing}>
-        {children}
-      </NovaEventingContext.Provider>
-    );
-  };
+  const reactEventing: NovaReactEventing = React.useMemo(
+    generateEventing(eventingRef, mapperRef),
+    [],
+  );
+
+  const reactUnmountEventing: NovaReactEventing = React.useMemo(
+    generateEventing(unmountEventingRef, mapperRef),
+    [],
+  );
+
+  return (
+    <NovaEventingContext.Provider
+      value={{ eventing: reactEventing, unmountEventing: reactUnmountEventing }}
+    >
+      {children}
+    </NovaEventingContext.Provider>
+  );
+};
 NovaEventingProvider.displayName = "NovaEventingProvider";
 
 export const useNovaEventing = (): NovaReactEventing => {
-  const eventing = React.useContext<NovaReactEventing | null>(
-    NovaEventingContext,
-  );
+  const { eventing } = React.useContext(NovaEventingContext);
   invariant(
     eventing,
-    "Nova Eventing provider must be initialized prior to consumption!",
+    "Nova Eventing provider must be initialized prior to consumption of eventing!",
   );
   return eventing;
 };
+
+export const useNovaUnmountEventing = (): NovaReactEventing => {
+  const { unmountEventing } = React.useContext(NovaEventingContext);
+  invariant(
+    unmountEventing,
+    "Nova Eventing provider must be initialized prior to consumption of unmountEventing!",
+  );
+  return unmountEventing;
+};
+
+const generateEventing =
+  (
+    eventingRef: React.MutableRefObject<NovaEventing>,
+    mapperRef: React.MutableRefObject<
+      (reactEventWrapper: ReactEventWrapper) => EventWrapper
+    >,
+  ) =>
+  () => ({
+    bubble: (eventWrapper: ReactEventWrapper) => {
+      const mappedEvent: EventWrapper = mapperRef.current(eventWrapper);
+      return eventingRef.current.bubble(mappedEvent);
+    },
+    generateEvent: (eventWrapper: GeneratedEventWrapper) => {
+      const mappedEvent = {
+        event: eventWrapper.event,
+        source: {
+          inputType: InputType.programmatic,
+          timeStamp: eventWrapper.timeStampOverride ?? Date.now(),
+        },
+      };
+      return eventingRef.current.bubble(mappedEvent);
+    },
+  });

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -6,7 +6,7 @@ import invariant from "invariant";
 // Context is initialized with an empty object and this is null-checked within the hooks
 const NovaEventingContext = React.createContext<INovaEventingContext>({});
 
-// Both are optional in the context for initialization state only, but eventing must be supplied in the props
+// Both properties are optional in the context for initialization state only, but eventing must be supplied in the props
 interface INovaEventingContext {
   eventing?: NovaReactEventing;
   unmountEventing?: NovaReactEventing;
@@ -14,7 +14,10 @@ interface INovaEventingContext {
 
 interface NovaEventingProviderProps {
   eventing: NovaEventing;
-  unmountEventing?: NovaEventing; // Optional version of eventing to use when unmounting, defaults to eventing if not supplied
+  /**
+   * Optional version of eventing to use when unmounting, defaults to eventing if not supplied via props
+   */
+  unmountEventing?: NovaEventing;
   /**
    * Mapping logic to transform a React SyntheticEvent into a Nova
    * Source object. Supply the Nova default implemenation using the import

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -89,10 +89,13 @@ export const NovaEventingProvider: React.FunctionComponent<
     [],
   );
 
+  const contextValue = React.useMemo(
+    () => ({ eventing: reactEventing, unmountEventing: reactUnmountEventing }),
+    [reactEventing, reactUnmountEventing],
+  );
+
   return (
-    <NovaEventingContext.Provider
-      value={{ eventing: reactEventing, unmountEventing: reactUnmountEventing }}
-    >
+    <NovaEventingContext.Provider value={contextValue}>
       {children}
     </NovaEventingContext.Provider>
   );


### PR DESCRIPTION
We've discovered a need to have two versions of eventing at once during component unmounts. Useeffect cleanup functions need to use the old version of eventing to get the old context to ensure proper routing of events. This change will allow hosts to maintain two eventing references, with the unmount eventing switching out later to keep the reference to the old execution context before unmount.

This change adds a useNovaUnmountEventing hook in the nova eventing provider. It is supplied by a new `unmountEventing` property. If the new property is not supplied, the new hook will use the existing eventing reference, to maintain backwards compatibility with nova hosts which do not need this functionality.