### PR TITLE
Add  support for Relay 13+ generated code by adding $fragmentSpreads support

### DIFF
--- a/change/@nova-react-8a6bad44-a7eb-4078-8e64-97d0eaeedc62.json
+++ b/change/@nova-react-8a6bad44-a7eb-4078-8e64-97d0eaeedc62.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for $fragmentSpreads format",
+  "packageName": "@nova/react",
+  "email": "mark@thedutchies.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/graphql/hooks.test.tsx
+++ b/packages/nova-react/src/graphql/hooks.test.tsx
@@ -135,6 +135,23 @@ describe(useFragment, () => {
       useFragment(fragment, opaqueFragmentRef);
     void _;
   });
+
+  it("supports the $fragmentSpreads format that is generated from Relay 13", () => {
+    type SomeFragment$data = { someKey: string };
+    type SomeFragment$key = {
+      readonly " $data"?: SomeFragment$data;
+      readonly " $fragmentSpreads": FragmentRefs<"SomeFragment">;
+    };
+
+    const fragment = {} as unknown as GraphQLTaggedNode;
+    const opaqueFragmentRef = {} as unknown as SomeFragment$key;
+
+    // This test just checks that there are no TS errors. Alas the test suite currently won't fail if that were the
+    // case, but at least there's a test that covers the intent.
+    const _: () => SomeFragment$data = () =>
+      useFragment(fragment, opaqueFragmentRef);
+    void _;
+  });
 });
 
 describe(useRefetchableFragment, () => {

--- a/packages/nova-react/src/graphql/types.ts
+++ b/packages/nova-react/src/graphql/types.ts
@@ -21,8 +21,10 @@ export interface _RefType<Ref extends string> {
   " $refType": Ref;
 }
 
-export interface _FragmentRefs<Refs extends string> {
+export type _FragmentRefs<Refs extends string> = {
   " $fragmentRefs": FragmentRefs<Refs>;
+} | {
+  " $fragmentSpreads": FragmentRefs<Refs>;
 }
 
 // This is used in the actual artifacts to define the various fragment references a container holds.
@@ -44,6 +46,9 @@ export type FragmentReference = unknown;
 export type KeyType<TData = unknown> = Readonly<{
   " $data"?: TData;
   " $fragmentRefs": FragmentReference;
+}> | Readonly<{
+  " $data"?: TData;
+  " $fragmentSpreads": FragmentReference;
 }>;
 
 export type KeyTypeData<


### PR DESCRIPTION
Relay 16 generates the following fragment type

```ts
export type JobTitleFragment$key = {
  readonly " $data"?: JobTitleFragment$data;
  readonly " $fragmentSpreads": FragmentRefs<"JobTitleFragment">;
};
```

Our hooks currently only support the older `" $fragmentRefs"` format that looks as follows.

```ts
export type JobTitleFragment$key = {
  readonly " $data"?: JobTitleFragment$data;
  readonly " $fragmentRefs": FragmentRefs<"JobTitleFragment">;
};
```

This means that when generating code with newer versions of the relay-compiler we can not use those generated fragments with `useFragment` and will get the following error.

```
Argument of type 'JobTitleFragment$key' is not assignable to parameter of type 'Readonly<{ " $data"?: unknown; " $fragmentRefs": unknown; }>'.
  Property '" $fragmentRefs"' is missing in type 'JobTitleFragment$key' but required in type 'Readonly<{ " $data"?: unknown; " $fragmentRefs": unknown; }>'.ts(2345)
types.d.ts(32, 5): '" $fragmentRefs"' is declared here.
```

This PR adds support for both variants which makes `useFragment` compatible with with Relay types < 13 and Relay > 13.