### PR TITLE
Allow React 18 to a peerDependency and fix Provider Prop types

### DIFF
--- a/change/@nova-react-901b72d6-78fa-4a51-9e04-ccf26c8e45bf.json
+++ b/change/@nova-react-901b72d6-78fa-4a51-9e04-ccf26c8e45bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix typings for React 18 and add ^18 to peerDependencies",
+  "packageName": "@nova/react",
+  "email": "mark@thedutchies.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/package.json
+++ b/packages/nova-react/package.json
@@ -14,8 +14,8 @@
     "nova-graphql-compiler": "./src/graphql/cli.js"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "@types/react": "^17.0.2",
+    "react": "^17.0.2 || ^18",
+    "@types/react": "^17.0.2 || ^18",
     "@graphitation/graphql-js-tag": "^0.9.0"
   },
   "dependencies": {

--- a/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
+++ b/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
@@ -10,7 +10,7 @@ interface NovaCentralizedCommandingProviderProps {
   commanding: NovaCentralizedCommanding;
 }
 
-export const NovaCentralizedCommandingProvider: React.FunctionComponent<NovaCentralizedCommandingProviderProps> =
+export const NovaCentralizedCommandingProvider: React.FunctionComponent<React.PropsWithChildren<NovaCentralizedCommandingProviderProps>> =
   ({ children, commanding }) => {
     return (
       <NovaCommandingContext.Provider value={commanding}>

--- a/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
+++ b/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
@@ -8,9 +8,10 @@ const NovaCommandingContext =
 
 interface NovaCentralizedCommandingProviderProps {
   commanding: NovaCentralizedCommanding;
+  children?: React.ReactNode | undefined;
 }
 
-export const NovaCentralizedCommandingProvider: React.FunctionComponent<React.PropsWithChildren<NovaCentralizedCommandingProviderProps>> =
+export const NovaCentralizedCommandingProvider: React.FunctionComponent<NovaCentralizedCommandingProviderProps> =
   ({ children, commanding }) => {
     return (
       <NovaCommandingContext.Provider value={commanding}>

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -24,6 +24,7 @@ interface NovaEventingProviderProps {
    * "mapEventMetadata".
    * */
   reactEventMapper: (reactEventWrapper: ReactEventWrapper) => EventWrapper;
+  children?: React.ReactNode | undefined;
 }
 
 export interface ReactEventWrapper {
@@ -58,7 +59,7 @@ export interface NovaReactEventing {
 }
 
 export const NovaEventingProvider: React.FunctionComponent<
-  React.PropsWithChildren<NovaEventingProviderProps>
+  NovaEventingProviderProps
 > = ({ children, eventing, unmountEventing, reactEventMapper }) => {
   // Nova contexts provide a facade over framework functions
   // We don't need to trigger rerender in children when we are rerendered

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -58,7 +58,7 @@ export interface NovaReactEventing {
 }
 
 export const NovaEventingProvider: React.FunctionComponent<
-  NovaEventingProviderProps
+  React.PropsWithChildren<NovaEventingProviderProps>
 > = ({ children, eventing, unmountEventing, reactEventMapper }) => {
   // Nova contexts provide a facade over framework functions
   // We don't need to trigger rerender in children when we are rerendered

--- a/packages/nova-react/src/graphql/nova-graphql-provider.tsx
+++ b/packages/nova-react/src/graphql/nova-graphql-provider.tsx
@@ -7,9 +7,10 @@ const NovaGraphQLContext = React.createContext<NovaGraphQL | null>(null);
 
 interface NovaGraphQLProviderProps {
   graphql: NovaGraphQL;
+  children?: React.ReactNode | undefined;
 }
 
-export const NovaGraphQLProvider: React.FunctionComponent<React.PropsWithChildren<NovaGraphQLProviderProps>> =
+export const NovaGraphQLProvider: React.FunctionComponent<NovaGraphQLProviderProps> =
   ({ children, graphql }) => {
     return (
       <NovaGraphQLContext.Provider value={graphql}>

--- a/packages/nova-react/src/graphql/nova-graphql-provider.tsx
+++ b/packages/nova-react/src/graphql/nova-graphql-provider.tsx
@@ -9,7 +9,7 @@ interface NovaGraphQLProviderProps {
   graphql: NovaGraphQL;
 }
 
-export const NovaGraphQLProvider: React.FunctionComponent<NovaGraphQLProviderProps> =
+export const NovaGraphQLProvider: React.FunctionComponent<React.PropsWithChildren<NovaGraphQLProviderProps>> =
   ({ children, graphql }) => {
     return (
       <NovaGraphQLContext.Provider value={graphql}>


### PR DESCRIPTION
When trying to use `@nova/react` with React 18 the typings for the providers are not correct as `children` now has to be explicitly defined on the Props type.

This adds the `children` prop to all the providers but keeps us on React 17 for now as that is what most of the internal projects still use. The fix should however allow React 18 users to use `@nova/react` without any errors.