### PR TITLE
feat(react-test-utils): add possibility to configure cache of mock client

### DIFF
--- a/change/@nova-react-test-utils-6eb41ac7-0d52-4bf2-a2d3-25a22cef2bc2.json
+++ b/change/@nova-react-test-utils-6eb41ac7-0d52-4bf2-a2d3-25a22cef2bc2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add possibility to pass options to mock client",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/README.md
+++ b/packages/nova-react-test-utils/README.md
@@ -107,7 +107,7 @@ export const LikeFailure: Story = {
   play: async (context) => {
     const {
       graphql: { mock },
-    } = getNovaEnvironmentDecorator(context);
+    } = getNovaEnvironmentForStory(context);
 
     // wait for next tick for apollo client to update state
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -124,7 +124,7 @@ export const LikeFailure: Story = {
 };
 ```
 
-This time resolvers are not queued up front so inside [play](https://storybook.js.org/docs/react/writing-stories/play-function#page-top) one needs to manually resolve/reject graphql operations. To get the environment created for this specific story one can use `getNovaEnvironmentDecorator` function. Later similarly to examples for unit test, full customization power of apollo-mock-client is available.
+This time resolvers are not queued up front so inside [play](https://storybook.js.org/docs/react/writing-stories/play-function#page-top) one needs to manually resolve/reject graphql operations. To get the environment created for this specific story one can use `getNovaEnvironmentForStory` function. Later similarly to examples for unit test, full customization power of apollo-mock-client is available.
 
 For more real life examples please check the [examples package](../examples/src/).
 

--- a/packages/nova-react-test-utils/README.md
+++ b/packages/nova-react-test-utils/README.md
@@ -132,6 +132,29 @@ You can also see that `satisfies NovaEnvironmentDecoratorParameters<TypeMap>` is
 
 ## FAQ
 
+#### I need to configure cache of the Apollo mock client as I am using @graphitation/apollo-react-relay-duct-tape together with watch fragments that rely on bein able to fetch data from cache. Is it configurable?
+
+Yes, if you are using through unit tests directly you can pass options to `createMockEnvironment`:
+
+```tsx
+const environment = createMockEnvironment(schema, {
+  cache: myCustomCacheConfig,
+});
+```
+
+and if you are using through storybook decorator you can pass options to `getNovaEnvironmentDecorator`:
+
+```tsx
+const meta: Meta<typeof FeedbackContainer> = {
+  component: FeedbackContainer,
+  decorators: [
+    getNovaEnvironmentDecorator(schema, {
+      cache: myCustomCacheConfig,
+    }),
+  ],
+};
+```
+
 #### How can I mock query/mutation/subscription?
 
 - [Query example](https://github.com/microsoft/graphitation/tree/main/packages/apollo-mock-client#query)

--- a/packages/nova-react-test-utils/src/storybook-nova-decorator.tsx
+++ b/packages/nova-react-test-utils/src/storybook-nova-decorator.tsx
@@ -36,6 +36,8 @@ type DefaultMockResolvers = Partial<{
   [key: string]: unknown;
 }>;
 
+type MockClientOptions = Parameters<typeof createMockClient>[1];
+
 export type NovaEnvironmentDecoratorParameters<
   T extends DefaultMockResolvers = DefaultMockResolvers,
 > = {
@@ -77,13 +79,14 @@ export const getNovaEnvironmentForStory = (
 
 export const getNovaEnvironmentDecorator: (
   schema: GraphQLSchema,
-) => MakeDecoratorResult = (schema) =>
+  options?: MockClientOptions,
+) => MakeDecoratorResult = (schema, options) =>
   makeDecorator({
     name: "withNovaEnvironment",
     parameterName: "novaEnvironment",
     wrapper: (getStory, context, settings) => {
       const environment = React.useMemo(
-        () => createNovaEnvironment(schema),
+        () => createNovaEnvironment(schema, options),
         [],
       );
       const parameters = settings.parameters as
@@ -113,8 +116,9 @@ export const getNovaEnvironmentDecorator: (
 
 function createNovaEnvironment(
   schema: GraphQLSchema,
+  options?: MockClientOptions,
 ): NovaMockEnvironment<"storybook"> {
-  const client = createMockClient(schema);
+  const client = createMockClient(schema, options);
   const env: NovaMockEnvironment<"storybook"> = {
     graphql: {
       ...(GraphQLHooks as NovaGraphQL),

--- a/packages/nova-react-test-utils/src/test-utils.tsx
+++ b/packages/nova-react-test-utils/src/test-utils.tsx
@@ -13,6 +13,8 @@ import { generate as payloadGenerator } from "@graphitation/graphql-js-operation
 import type { GraphQLTaggedNode } from "@nova/react";
 import type { NovaGraphQL } from "@nova/types";
 
+type MockClientOptions = Parameters<typeof createMockClient>[1];
+
 type Generate<Schema, Node> = (
   operation: OperationDescriptor<Schema, Node>,
   mockResolvers?: Parameters<typeof payloadGenerator>[1],
@@ -34,8 +36,9 @@ export const MockPayloadGenerator: {
  */
 export function createMockEnvironment(
   schema: GraphQLSchema,
+  options?: MockClientOptions,
 ): NovaMockEnvironment {
-  const client = createMockClient(schema);
+  const client = createMockClient(schema, options);
   const env: NovaMockEnvironment = {
     commanding: {
       trigger: jest.fn(),


### PR DESCRIPTION
In Jana we want to rely on `@graphitation/apollo-react-relay-duct-tape` with watch fragments to be able to use `useReftchable/PaginationFragment` hooks. However, to get them to work one needs a specific cache config for apollo client, even for the mock one. In this PR we add an option to pass that, matching interface of apollo-mock-client itself