### PR TITLE
Added optional source to GeneratedEventWrapper

### DIFF
--- a/change/@nova-react-59088fac-99ff-4d48-bf7c-568225e9b705.json
+++ b/change/@nova-react-59088fac-99ff-4d48-bf7c-568225e9b705.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added optional source to GeneratedEventWrapper, will generate with source if source is passed with eventWrapper",
+  "packageName": "@nova/react",
+  "email": "kennetvuong@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import type { NovaEvent, NovaEventing, EventWrapper } from "@nova/types";
+import type {
+  NovaEvent,
+  NovaEventing,
+  EventWrapper,
+  Source,
+} from "@nova/types";
 import { InputType } from "@nova/types";
 import invariant from "invariant";
 
@@ -37,6 +42,10 @@ export interface ReactEventWrapper {
 
 export interface GeneratedEventWrapper {
   event: NovaEvent<unknown>;
+  /**
+   * Optional details about the originating event like input method and timestamp
+   */
+  source?: Source;
   /**
    * Optional timestamp in milliseconds since epoch format,
    * by default will use Date.now() if override not supplied.
@@ -142,7 +151,7 @@ const generateEventing =
     generateEvent: (eventWrapper: GeneratedEventWrapper) => {
       const mappedEvent = {
         event: eventWrapper.event,
-        source: {
+        source: eventWrapper.source ?? {
           inputType: InputType.programmatic,
           timeStamp: eventWrapper.timeStampOverride ?? Date.now(),
         },


### PR DESCRIPTION
We are currently integrating Jana into Outlook Web(OWA) and we need a way to catch a NovaEvent and then bubble it to parent provider if we dont want to deal with it. We are doing this by calling `generateEvent(event)`, but with current `generateEvent(event)`, source is generated on each call, which means we will lose metadata about `source` if it already exists in the event. 

By adding a optional field `source`, we can generate only if `source` is not defined.