### PR TITLE
Allow fragment refs to be null or undefined

### DIFF
--- a/change/@nova-react-c10c9e36-4cda-4e41-bc32-85c8d2031bdb.json
+++ b/change/@nova-react-c10c9e36-4cda-4e41-bc32-85c8d2031bdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make fragment ref nullable",
+  "packageName": "@nova/react",
+  "email": "mark@thedutchies.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/package.json
+++ b/packages/nova-react/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@graphitation/graphql-js-tag": "^0.9.0",
     "@testing-library/react": "^12.0.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/invariant": "^2.2.35",
     "@types/jest": "^29.2.0",
     "@types/react": "^17.0.2",

--- a/packages/nova-react/src/graphql/hooks.test.tsx
+++ b/packages/nova-react/src/graphql/hooks.test.tsx
@@ -498,7 +498,7 @@ describe(usePaginationFragment, () => {
     void _;
   });
 
-  it("allows null to be passed as a fragment ref and returns null or undefined", () => {
+  it("allows fragment ref, null, or undefined to be passed as a fragment ref and returns data, null, or undefined", () => {
     const graphql: NovaGraphQL = {
       usePaginationFragment: jest.fn().mockImplementation(() => ({
         data: {},
@@ -535,7 +535,7 @@ describe(usePaginationFragment, () => {
     void _;
   });
 
-  it("allows null to be passed as a fragment ref and returns null or undefined", () => {
+  it("allows null or undefined to be passed as a fragment ref and returns null or undefined", () => {
     const graphql: NovaGraphQL = {
       usePaginationFragment: jest.fn().mockImplementation(() => ({
         data: {},

--- a/packages/nova-react/src/graphql/hooks.test.tsx
+++ b/packages/nova-react/src/graphql/hooks.test.tsx
@@ -19,8 +19,8 @@ import {
 import type { GraphQLTaggedNode } from "./taggedNode";
 import type { FragmentRefs } from "./types";
 
-type NotNull<T> = null extends T ? false : true;
-type NotUndefined<T> = undefined extends T ? false : true;
+type IsNotNull<T> = null extends T ? false : true;
+type IsNotUndefined<T> = undefined extends T ? false : true;
 
 describe(useLazyLoadQuery, () => {
   it("ensures an implementation is supplied", () => {
@@ -218,8 +218,8 @@ describe(useFragment, () => {
 
       type ExpectedReturnType = typeof data;
 
-      const _: NotNull<ExpectedReturnType> = true;
-      const __: NotUndefined<ExpectedReturnType> = true;
+      const _: IsNotNull<ExpectedReturnType> = true;
+      const __: IsNotUndefined<ExpectedReturnType> = true;
       const ___: ExpectedReturnType = { someKey: "some-data" };
 
       // Workaround for TS complaining about unused variables
@@ -343,8 +343,8 @@ describe(useRefetchableFragment, () => {
 
     type ExpectedReturnType = (typeof result.current)[0];
 
-    const _: NotNull<ExpectedReturnType> = true;
-    const __: NotUndefined<ExpectedReturnType> = true;
+    const _: IsNotNull<ExpectedReturnType> = true;
+    const __: IsNotUndefined<ExpectedReturnType> = true;
     const ___: ExpectedReturnType = { someKey: "some-data " };
 
     // Workaround for TS complaining about unused variables
@@ -383,8 +383,8 @@ describe(useRefetchableFragment, () => {
 
     type ExpectedReturnType = (typeof result.current)[0];
 
-    const _: NotNull<ExpectedReturnType> = false;
-    const __: NotUndefined<ExpectedReturnType> = false;
+    const _: IsNotNull<ExpectedReturnType> = false;
+    const __: IsNotUndefined<ExpectedReturnType> = false;
     const ___: ExpectedReturnType = { someKey: "some-data " };
 
     // Workaround for TS complaining about unused variables

--- a/packages/nova-react/src/graphql/hooks.ts
+++ b/packages/nova-react/src/graphql/hooks.ts
@@ -136,7 +136,7 @@ export function useLazyLoadQuery<TQuery extends OperationType>(
  */
 export function useFragment(
   fragmentInput: GraphQLTaggedNode,
-  fragmentRef: null | undefined, // This overload makes sure we do not get `unknown` as the return type.
+  fragmentRef: null | undefined,
 ): null | undefined;
 export function useFragment<TKey extends KeyType>(
   fragmentInput: GraphQLTaggedNode,
@@ -223,6 +223,7 @@ export function useRefetchableFragment<
 
 export function usePaginationFragment<
   TQuery extends OperationType,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   TKey extends null | undefined,
 >(
   fragmentInput: GraphQLTaggedNode,

--- a/packages/nova-react/src/graphql/hooks.ts
+++ b/packages/nova-react/src/graphql/hooks.ts
@@ -60,7 +60,7 @@ import type {
 export function useLazyLoadQuery<TQuery extends OperationType>(
   query: GraphQLTaggedNode,
   variables: TQuery["variables"],
-  options?: { fetchPolicy?: "cache-first"; context?: TQuery["context"] }
+  options?: { fetchPolicy?: "cache-first"; context?: TQuery["context"] },
 ): { error?: Error; data?: TQuery["response"] } {
   const graphql = useNovaGraphQL();
   invariant(
@@ -134,10 +134,23 @@ export function useLazyLoadQuery<TQuery extends OperationType>(
  *                    fragment.
  * @returns The data corresponding to the field selections.
  */
+export function useFragment(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: null | undefined, // This overload makes sure we do not get `unknown` as the return type.
+): null | undefined;
 export function useFragment<TKey extends KeyType>(
   fragmentInput: GraphQLTaggedNode,
   fragmentRef: TKey,
-): KeyTypeData<TKey> {
+): KeyTypeData<TKey>;
+export function useFragment<TKey extends KeyType>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: TKey | null | undefined,
+): KeyTypeData<TKey> | null | undefined;
+
+export function useFragment<TKey extends KeyType>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: TKey | null | undefined,
+): KeyTypeData<TKey> | null | undefined {
   return (
     useNovaGraphQL().useFragment?.(fragmentInput, fragmentRef) || fragmentRef
   );
@@ -155,11 +168,40 @@ export function useFragment<TKey extends KeyType>(
  */
 export function useRefetchableFragment<
   TQuery extends OperationType,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _TKey extends KeyType,
+>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: null | undefined,
+): [data: null | undefined, refetch: RefetchFn<TQuery["variables"]>];
+export function useRefetchableFragment<
+  TQuery extends OperationType,
   TKey extends KeyType,
 >(
   fragmentInput: GraphQLTaggedNode,
   fragmentRef: TKey,
-): [data: KeyTypeData<TKey>, refetch: RefetchFn<TQuery["variables"]>] {
+): [data: KeyTypeData<TKey>, refetch: RefetchFn<TQuery["variables"]>];
+export function useRefetchableFragment<
+  TQuery extends OperationType,
+  TKey extends KeyType,
+>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: TKey | null | undefined,
+): [
+  data: KeyTypeData<TKey> | null | undefined,
+  refetch: RefetchFn<TQuery["variables"]>,
+];
+
+export function useRefetchableFragment<
+  TQuery extends OperationType,
+  TKey extends KeyType,
+>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: TKey | null | undefined,
+): [
+  data: KeyTypeData<TKey> | null | undefined,
+  refetch: RefetchFn<TQuery["variables"]>,
+] {
   const graphql = useNovaGraphQL();
   invariant(
     graphql.useRefetchableFragment,
@@ -178,6 +220,23 @@ export function useRefetchableFragment<
  *                    fragment.
  * @returns The data corresponding to the field selections and functions to deal with pagination.
  */
+
+export function usePaginationFragment<
+  TQuery extends OperationType,
+  TKey extends null | undefined,
+>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: null | undefined,
+): {
+  data: null | undefined;
+  loadNext: PaginationFn;
+  loadPrevious: PaginationFn;
+  hasNext: boolean;
+  hasPrevious: boolean;
+  isLoadingNext: boolean;
+  isLoadingPrevious: boolean;
+  refetch: RefetchFn<TQuery["variables"]>;
+};
 export function usePaginationFragment<
   TQuery extends OperationType,
   TKey extends KeyType,
@@ -186,6 +245,39 @@ export function usePaginationFragment<
   fragmentRef: TKey,
 ): {
   data: KeyTypeData<TKey>;
+  loadNext: PaginationFn;
+  loadPrevious: PaginationFn;
+  hasNext: boolean;
+  hasPrevious: boolean;
+  isLoadingNext: boolean;
+  isLoadingPrevious: boolean;
+  refetch: RefetchFn<TQuery["variables"]>;
+};
+export function usePaginationFragment<
+  TQuery extends OperationType,
+  TKey extends KeyType,
+>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: TKey | null | undefined,
+): {
+  data: KeyTypeData<TKey> | null | undefined;
+  loadNext: PaginationFn;
+  loadPrevious: PaginationFn;
+  hasNext: boolean;
+  hasPrevious: boolean;
+  isLoadingNext: boolean;
+  isLoadingPrevious: boolean;
+  refetch: RefetchFn<TQuery["variables"]>;
+};
+
+export function usePaginationFragment<
+  TQuery extends OperationType,
+  TKey extends KeyType,
+>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: TKey | null | undefined,
+): {
+  data: KeyTypeData<TKey> | null | undefined;
   loadNext: PaginationFn;
   loadPrevious: PaginationFn;
   hasNext: boolean;

--- a/packages/nova-react/src/graphql/types.ts
+++ b/packages/nova-react/src/graphql/types.ts
@@ -3,7 +3,7 @@ export interface Variables {
 }
 
 export interface Context {
-  [name: string]: any
+  [name: string]: any;
 }
 
 export interface OperationType {
@@ -21,11 +21,13 @@ export interface _RefType<Ref extends string> {
   " $refType": Ref;
 }
 
-export type _FragmentRefs<Refs extends string> = {
-  " $fragmentRefs": FragmentRefs<Refs>;
-} | {
-  " $fragmentSpreads": FragmentRefs<Refs>;
-}
+export type _FragmentRefs<Refs extends string> =
+  | {
+      " $fragmentRefs": FragmentRefs<Refs>;
+    }
+  | {
+      " $fragmentSpreads": FragmentRefs<Refs>;
+    };
 
 // This is used in the actual artifacts to define the various fragment references a container holds.
 export type FragmentRefs<Refs extends string> = {
@@ -43,13 +45,15 @@ export type FragmentRef<Fragment> = Fragment extends _RefType<infer U>
 
 export type FragmentReference = unknown;
 
-export type KeyType<TData = unknown> = Readonly<{
-  " $data"?: TData;
-  " $fragmentRefs": FragmentReference;
-}> | Readonly<{
-  " $data"?: TData;
-  " $fragmentSpreads": FragmentReference;
-}>;
+export type KeyType<TData = unknown> =
+  | Readonly<{
+      " $data"?: TData;
+      " $fragmentRefs": FragmentReference;
+    }>
+  | Readonly<{
+      " $data"?: TData;
+      " $fragmentSpreads": FragmentReference;
+    }>;
 
 export type KeyTypeData<
   TKey extends KeyType<TData>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,6 +3014,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^12.0.0":
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.1.tgz#e693943aa48d0190099acdc3928a751d73bcf7d5"
@@ -9097,6 +9105,13 @@ react-element-to-jsx-string@^15.0.0:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "18.1.0"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-inspector@^6.0.0:
   version "6.0.1"


### PR DESCRIPTION
Relay allows for fragment references  to be `null` or `undefined`. Our typings have been stricter where they do not allow `null` or `undefined`. 

This causes us to miss out on things like `@skip` and `@include`.

This PR adds the ability to pass `null` or `undefined` as the fragment reference to `useFragment` `usePaginationFragment` or `useRefetchableFragment`.