### PR TITLE
Bump duct tape version for package deduplication and make compiler test work on windows

### DIFF
--- a/change/@nova-graphql-compiler-e72520b4-ef21-4e7e-b424-2ea556b89389.json
+++ b/change/@nova-graphql-compiler-e72520b4-ef21-4e7e-b424-2ea556b89389.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "make test for compiler work on windows",
+  "packageName": "@nova/graphql-compiler",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@nova-react-test-utils-0110d9fc-466e-4726-90dc-ee51b696c71e.json
+++ b/change/@nova-react-test-utils-0110d9fc-466e-4726-90dc-ee51b696c71e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "use newer version of duct tape",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-graphql-compiler/package.json
+++ b/packages/nova-graphql-compiler/package.json
@@ -19,6 +19,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
+    "cross-spawn": "^7.0.0",
     "monorepo-scripts": "*"
   },
   "repository": {

--- a/packages/nova-graphql-compiler/src/cli.test.js
+++ b/packages/nova-graphql-compiler/src/cli.test.js
@@ -1,4 +1,4 @@
-const { spawnSync } = require("child_process");
+const { spawn } = require("cross-spawn");
 const { readFile, rm } = require("fs/promises");
 const path = require("path/posix");
 
@@ -11,7 +11,7 @@ describe("cli", () => {
     });
 
     // Run the compiler
-    spawnSync(
+    spawn.sync(
       "./src/cli.js",
       [
         "--schema",

--- a/packages/nova-react-test-utils/package.json
+++ b/packages/nova-react-test-utils/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.15",
     "@graphitation/apollo-mock-client": "^0.11.0",
-    "@graphitation/apollo-react-relay-duct-tape": "^0.8.2",
+    "@graphitation/apollo-react-relay-duct-tape": "^1.0.30",
     "@graphitation/graphql-js-operation-payload-generator": "^0.12.0",
     "@graphitation/graphql-js-tag": "^0.9.0",
     "@nova/react": "^1.6.0",
@@ -31,6 +31,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
+    "@graphitation/apollo-react-relay-duct-tape-compiler": "^1.4.0",
     "@storybook/react": "^7.0.11",
     "@storybook/types": "^7.0.11",
     "@testing-library/react": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,12 +1284,24 @@
   dependencies:
     invariant "^2.2.4"
 
-"@graphitation/apollo-react-relay-duct-tape@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@graphitation/apollo-react-relay-duct-tape/-/apollo-react-relay-duct-tape-0.8.2.tgz#7f57e65e3ebe9afa68be62fefd5d85690629e2a0"
-  integrity sha512-zW3A2QaU8GhzrJPcx6+WI3csQSTQKdKayY7+farCB4eiWBIar4eANBLyz8hxpxGGEwbbnmT+esZD1UFM3fV02w==
+"@graphitation/apollo-react-relay-duct-tape-compiler@^1.4.0":
+  version "1.4.0"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphitation/apollo-react-relay-duct-tape-compiler/-/apollo-react-relay-duct-tape-compiler-1.4.0.tgz#26df7100b6cf5e33a72cd22fbd48d85acbd2cc68"
+  integrity sha1-Jt9xALbPXjOnLNIvvUjYWsvSzGg=
+  dependencies:
+    "@graphitation/graphql-js-tag" "^0.9.1"
+    "@graphql-tools/optimize" "^1.1.1"
+    relay-compiler "^12.0.0"
+    relay-compiler-language-typescript "^15.0.1"
+    yargs "^16.2.0"
+
+"@graphitation/apollo-react-relay-duct-tape@^1.0.30":
+  version "1.0.30"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphitation/apollo-react-relay-duct-tape/-/apollo-react-relay-duct-tape-1.0.30.tgz#a3c3211a675cab4832d55d5ad74fec65494cb9d9"
+  integrity sha1-o8MhGmdcq0gy1V1a10/sZUlMudk=
   dependencies:
     invariant "^2.2.4"
+    lodash "^4.17.15"
 
 "@graphitation/graphql-codegen-typescript-typemap-plugin@^0.1.5":
   version "0.1.5"
@@ -1309,6 +1321,13 @@
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@graphitation/graphql-js-tag/-/graphql-js-tag-0.9.0.tgz#4e368c5b43809123866b0400f96e460386e43fb6"
   integrity sha512-TgRtUE6XurM6jz9FXdP+hxfEhzdWT/mljBCN03sFuEtyMpTfLjPYTd0QfqXbFd5fTnt1Yjfm2Vu0bB1Jz7cKEg==
+  dependencies:
+    invariant "^2.0.0"
+
+"@graphitation/graphql-js-tag@^0.9.1":
+  version "0.9.1"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphitation/graphql-js-tag/-/graphql-js-tag-0.9.1.tgz#e40bef3a58ce553f1f40eab262e5ab263d5225bc"
+  integrity sha1-5AvvOljOVT8fQOqyYuWrJj1SJbw=
   dependencies:
     invariant "^2.0.0"
 
@@ -1621,6 +1640,13 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-1.3.1.tgz#29407991478dbbedc3e7deb8c44f46acb4e9278b"
   integrity sha512-5j5CZSRGWVobt4bgRRg7zhjPiSimk+/zIuColih8E8DxuFOaJ+t0qu7eZS5KXWBkjcd4BPNuhUPpNlEmHPqVRQ==
+  dependencies:
+    tslib "^2.4.0"
+
+"@graphql-tools/optimize@^1.1.1":
+  version "1.4.0"
+  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphql-tools/optimize/-/optimize-1.4.0.tgz#20d6a9efa185ef8fc4af4fd409963e0907c6e112"
+  integrity sha1-INap76GF74/Er0/UCZY+CQfG4RI=
   dependencies:
     tslib "^2.4.0"
 
@@ -9284,7 +9310,7 @@ relay-compiler-language-graphitation@^0.8.2:
     relay-compiler-language-typescript ">=14.0.0"
     typescript ">=4.2.3"
 
-relay-compiler-language-typescript@>=14.0.0:
+relay-compiler-language-typescript@>=14.0.0, relay-compiler-language-typescript@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/relay-compiler-language-typescript/-/relay-compiler-language-typescript-15.0.1.tgz#78e952cdf6d7c9f833f168c6f8765e985a791d3d"
   integrity sha512-hy760TxYhylNhSDkkxrQJvEqbhtknE8YtzmY+tRpgKGCq1Axi7eh3YjCLmfc3P2jumJXNEROQTkqqz8IbgU+tg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,8 +1286,8 @@
 
 "@graphitation/apollo-react-relay-duct-tape-compiler@^1.4.0":
   version "1.4.0"
-  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphitation/apollo-react-relay-duct-tape-compiler/-/apollo-react-relay-duct-tape-compiler-1.4.0.tgz#26df7100b6cf5e33a72cd22fbd48d85acbd2cc68"
-  integrity sha1-Jt9xALbPXjOnLNIvvUjYWsvSzGg=
+  resolved "https://registry.yarnpkg.com/@graphitation/apollo-react-relay-duct-tape-compiler/-/apollo-react-relay-duct-tape-compiler-1.4.0.tgz#26df7100b6cf5e33a72cd22fbd48d85acbd2cc68"
+  integrity sha512-f81AHWRpGjRTovfJu7ePGPcuJ6y1v4ihKB2g6An5BlqNLrbByR3jyGfrBOyxaqFYgsmvDwtyEZqXy9hCFDL3ag==
   dependencies:
     "@graphitation/graphql-js-tag" "^0.9.1"
     "@graphql-tools/optimize" "^1.1.1"
@@ -1297,8 +1297,8 @@
 
 "@graphitation/apollo-react-relay-duct-tape@^1.0.30":
   version "1.0.30"
-  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphitation/apollo-react-relay-duct-tape/-/apollo-react-relay-duct-tape-1.0.30.tgz#a3c3211a675cab4832d55d5ad74fec65494cb9d9"
-  integrity sha1-o8MhGmdcq0gy1V1a10/sZUlMudk=
+  resolved "https://registry.yarnpkg.com/@graphitation/apollo-react-relay-duct-tape/-/apollo-react-relay-duct-tape-1.0.30.tgz#a3c3211a675cab4832d55d5ad74fec65494cb9d9"
+  integrity sha512-G5wdpzCOO2g6We3XY2NJyz3lh4IZQAuKo1RI3Kwp7SMxN02nfQGOS2ZVHLxuK+Mh1fwGWzlmr7tw+kk+sZwV3g==
   dependencies:
     invariant "^2.2.4"
     lodash "^4.17.15"
@@ -1319,8 +1319,8 @@
 
 "@graphitation/graphql-js-tag@^0.9.0", "@graphitation/graphql-js-tag@^0.9.1":
   version "0.9.1"
-  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphitation/graphql-js-tag/-/graphql-js-tag-0.9.1.tgz#e40bef3a58ce553f1f40eab262e5ab263d5225bc"
-  integrity sha1-5AvvOljOVT8fQOqyYuWrJj1SJbw=
+  resolved "https://registry.yarnpkg.com/@graphitation/graphql-js-tag/-/graphql-js-tag-0.9.1.tgz#e40bef3a58ce553f1f40eab262e5ab263d5225bc"
+  integrity sha512-qBV+2JGFRtASwM4Tnsfd6WkMSdvKJjm4IKeyUp7gNCxvl12cumXVbR7QxRY2qLRZHk6Pd2LZGqqS6iJAn19/nQ==
   dependencies:
     invariant "^2.0.0"
 
@@ -1638,8 +1638,8 @@
 
 "@graphql-tools/optimize@^1.1.1", "@graphql-tools/optimize@^1.3.0":
   version "1.4.0"
-  resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphql-tools/optimize/-/optimize-1.4.0.tgz#20d6a9efa185ef8fc4af4fd409963e0907c6e112"
-  integrity sha1-INap76GF74/Er0/UCZY+CQfG4RI=
+  resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-1.4.0.tgz#20d6a9efa185ef8fc4af4fd409963e0907c6e112"
+  integrity sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==
   dependencies:
     tslib "^2.4.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1317,14 +1317,7 @@
   dependencies:
     deepmerge "^4.2.2"
 
-"@graphitation/graphql-js-tag@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@graphitation/graphql-js-tag/-/graphql-js-tag-0.9.0.tgz#4e368c5b43809123866b0400f96e460386e43fb6"
-  integrity sha512-TgRtUE6XurM6jz9FXdP+hxfEhzdWT/mljBCN03sFuEtyMpTfLjPYTd0QfqXbFd5fTnt1Yjfm2Vu0bB1Jz7cKEg==
-  dependencies:
-    invariant "^2.0.0"
-
-"@graphitation/graphql-js-tag@^0.9.1":
+"@graphitation/graphql-js-tag@^0.9.0", "@graphitation/graphql-js-tag@^0.9.1":
   version "0.9.1"
   resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphitation/graphql-js-tag/-/graphql-js-tag-0.9.1.tgz#e40bef3a58ce553f1f40eab262e5ab263d5225bc"
   integrity sha1-5AvvOljOVT8fQOqyYuWrJj1SJbw=
@@ -1636,14 +1629,14 @@
     "@graphql-tools/utils" "9.2.1"
     tslib "^2.4.0"
 
-"@graphql-tools/optimize@1.3.1", "@graphql-tools/optimize@^1.3.0":
+"@graphql-tools/optimize@1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-1.3.1.tgz#29407991478dbbedc3e7deb8c44f46acb4e9278b"
   integrity sha512-5j5CZSRGWVobt4bgRRg7zhjPiSimk+/zIuColih8E8DxuFOaJ+t0qu7eZS5KXWBkjcd4BPNuhUPpNlEmHPqVRQ==
   dependencies:
     tslib "^2.4.0"
 
-"@graphql-tools/optimize@^1.1.1":
+"@graphql-tools/optimize@^1.1.1", "@graphql-tools/optimize@^1.3.0":
   version "1.4.0"
   resolved "https://domoreexp.pkgs.visualstudio.com/_packaging/npm-mirror/npm/registry/@graphql-tools/optimize/-/optimize-1.4.0.tgz#20d6a9efa185ef8fc4af4fd409963e0907c6e112"
   integrity sha1-INap76GF74/Er0/UCZY+CQfG4RI=


### PR DESCRIPTION
There are two issues that this PR is trying to fix:
* running tests for compiler fails on windows because `spawnSync` is not cross platform
* repoes which depend on @nova/react-test-utils have to force version of duct tape as the current range is not deduplicatble with 1.x.

We fix both