### PR TITLE
fix(nova-react-test-utils): fix StoryObjWithoutFragmentRefs type

### DIFF
--- a/change/@nova-react-test-utils-c3c25173-e0c9-493b-b4f3-682a4a4e0f42.json
+++ b/change/@nova-react-test-utils-c3c25173-e0c9-493b-b4f3-682a4a4e0f42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix a type",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/src/shared/types.d-test.ts
+++ b/packages/nova-react-test-utils/src/shared/types.d-test.ts
@@ -19,15 +19,25 @@ type Props = {
   requiredProp: string;
   optionalProp?: string;
 };
-const Component: React.FC<Props> = (_: Props) => null;
 
 type OptionalProps = {
   propPassedThroughDecorator: unknown;
   optionalProp?: string;
 };
 
+type OptionalPropsOnly = {
+  propPassedThroughDecorator?: unknown;
+  optionalProp?: string;
+};
+
+const Component: React.FC<Props> = (_: Props) => null;
+
 const ComponentWithOptionalProps: React.FC<OptionalProps> = (
   _: OptionalProps,
+) => null;
+
+const ComponentWithOptionalPropsOnly: React.FC<OptionalPropsOnly> = (
+  _: OptionalPropsOnly,
 ) => null;
 
 const parameters = {
@@ -66,6 +76,11 @@ const metaForComponentWithOptionalProps = {
   parameters,
 } satisfies Meta<typeof ComponentWithOptionalProps>;
 
+const metaForComponentWithOptionalPropsOnly = {
+  component: ComponentWithOptionalPropsOnly,
+  parameters,
+} satisfies Meta<typeof ComponentWithOptionalPropsOnly>;
+
 type StoryObjForMeta = StoryObj<typeof meta>;
 type StoryObjWithoutFragmentRefsForMeta = StoryObjWithoutFragmentRefs<
   typeof meta
@@ -102,6 +117,14 @@ const StoryWithoutArgsForMetaWithArgs: StoryObjWithoutFragmentRefs<
   typeof metaWithArgs
 > = {};
 
+const StoryForComponentWithOptionalPropsOnly: StoryObjWithoutFragmentRefs<
+  typeof metaForComponentWithOptionalPropsOnly
+> = {
+  args: {
+    optionalProp: "optional",
+  },
+};
+
 type WithoutDecoratorParamsItShouldBeNever = Expect<
   Equal<never, StoryObjWithoutFragmentRefs<typeof metaWithoutDecoratorParams>>
 >;
@@ -127,3 +150,12 @@ type VerifyTypeContainsRequiredPropAndDoesntContainOneFromReferenceEntries =
       { requiredProp: string; optionalProp?: string }
     >
   >;
+
+type VerifyArgsTypeWhenComponentHasRequiredPropsOnly = Expect<
+  Equal<
+    StoryObjWithoutFragmentRefs<
+      typeof metaForComponentWithOptionalPropsOnly
+    >["args"],
+    { optionalProp?: string } | undefined
+  >
+>;

--- a/packages/nova-react-test-utils/src/shared/types.ts
+++ b/packages/nova-react-test-utils/src/shared/types.ts
@@ -1,12 +1,12 @@
 import type { StoryObj } from "@storybook/react";
 import type { Simplify, RequiredKeysOf } from "type-fest";
 
-type RequiredArgs<T> = T extends { args: infer A }
+type RequiredArgs<T> = T extends { args?: infer A }
   ? A extends object
     ? Pick<A, RequiredKeysOf<A>>
     : never
   : never;
-type OptionalArgs<T> = T extends { args: infer A }
+type OptionalArgs<T> = T extends { args?: infer A }
   ? A extends object
     ? Omit<A, RequiredKeysOf<A>>
     : never


### PR DESCRIPTION
In #114 we added improved types but turns out we missed one case for components which have optional props only. Let's fix this and add a type test.