### PR TITLE
fix(nova-react-test-utils): prevent component unmount when using decorator with RTL rerender

### DIFF
--- a/change/@nova-examples-c7b407c4-0f7d-4998-9e44-6060439c77d4.json
+++ b/change/@nova-examples-c7b407c4-0f7d-4998-9e44-6060439c77d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add test for RTL rerender",
+  "packageName": "@nova/examples",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-react-test-utils-2c56a133-6ab5-4005-b9c8-e62c10473986.json
+++ b/change/@nova-react-test-utils-2c56a133-6ab5-4005-b9c8-e62c10473986.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "don't unmount on RTL rerender",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/examples/src/apollo/Feedback/Feedback.test.tsx
+++ b/packages/examples/src/apollo/Feedback/Feedback.test.tsx
@@ -5,11 +5,48 @@ import * as React from "react";
 import "@testing-library/jest-dom";
 import { prepareStoryContextForTest } from "@nova/react-test-utils/apollo";
 import { executePlayFunction } from "../../testing-utils/executePlayFunction";
+import type { EventWrapper, NovaEventing } from "@nova/types";
 
-const { ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError } =
-  composeStories(stories);
+const {
+  ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError,
+  Primary,
+} = composeStories(stories);
+
+const bubbleMock = jest.fn<NovaEventing, [EventWrapper]>();
+const generateEventMock = jest.fn<NovaEventing, [EventWrapper]>();
+
+jest.mock("@nova/react", () => ({
+  ...jest.requireActual("@nova/react"),
+  useNovaEventing: () => ({
+    bubble: bubbleMock,
+    generateEvent: generateEventMock,
+  }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("Feedback", () => {
+  it("rerenders without unmounting", async () => {
+    const { rerender, findByRole } = render(<Primary />);
+    await findByRole("button", { name: "Like" });
+
+    let telemetryEvents = generateEventMock.mock.calls.filter(
+      ([{ event }]) => event.type === "feedbackTelemetry",
+    );
+
+    expect(telemetryEvents).toHaveLength(1); // coming from strict mode
+
+    rerender(<Primary />);
+    await findByRole("button", { name: "Like" });
+
+    telemetryEvents = generateEventMock.mock.calls.filter(
+      ([{ event }]) => event.type === "feedbackTelemetry",
+    );
+    expect(telemetryEvents).toHaveLength(1); // there are no remounts of the component on Story rerender
+  });
+
   it("throws an error when the developer makes a mistake", async () => {
     const { container } = render(
       <ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError />,

--- a/packages/examples/src/apollo/Feedback/Feedback.tsx
+++ b/packages/examples/src/apollo/Feedback/Feedback.tsx
@@ -1,13 +1,11 @@
-import {
-  graphql,
-  useFragment,
-  useMutation,
-  useNovaEventing,
-} from "@nova/react";
+import { graphql, useFragment, useMutation } from "@nova/react";
 import * as React from "react";
 import type { FeedbackComponent_LikeMutation } from "./__generated__/FeedbackComponent_LikeMutation.graphql";
 import type { Feedback_feedbackFragment$key } from "./__generated__/Feedback_feedbackFragment.graphql";
-import { events } from "../../events/events";
+import {
+  useOnDeleteFeedback,
+  useFeedbackTelemetry,
+} from "../../events/helpers";
 
 type Props = {
   feedback: Feedback_feedbackFragment$key;
@@ -44,6 +42,12 @@ export const FeedbackComponent = (props: Props) => {
   );
 
   const feedbackTelemetry = useFeedbackTelemetry();
+
+  React.useEffect(() => {
+    return () => {
+      feedbackTelemetry("FeedbackComponentUnmounted");
+    };
+  }, []);
 
   return (
     <div
@@ -93,29 +97,5 @@ export const FeedbackComponent = (props: Props) => {
       </button>
       <button onClick={onDeleteFeedback}>Delete feedback</button>
     </div>
-  );
-};
-
-const useOnDeleteFeedback = (feedbackId: string, feedbackText: string) => {
-  const eventing = useNovaEventing();
-
-  return React.useCallback(
-    (reactEvent: React.SyntheticEvent) => {
-      const event = events.onDeleteFeedback({ feedbackId, feedbackText });
-      void eventing.bubble({ event, reactEvent });
-    },
-    [eventing, feedbackId, feedbackText],
-  );
-};
-
-const useFeedbackTelemetry = () => {
-  const eventing = useNovaEventing();
-
-  return React.useCallback(
-    (operation: "FeedbackLiked" | "FeedbackUnliked") => {
-      const event = events.feedbackTelemetry({ operation });
-      void eventing.generateEvent({ event });
-    },
-    [eventing],
   );
 };

--- a/packages/examples/src/events/events.ts
+++ b/packages/examples/src/events/events.ts
@@ -6,7 +6,7 @@ type DeleteFeedbackRequest = {
 };
 
 type FeedbackTelemetryRequest = {
-  operation: "FeedbackLiked" | "FeedbackUnliked";
+  operation: "FeedbackLiked" | "FeedbackUnliked" | "FeedbackComponentUnmounted";
 };
 
 export const originator = "Feedback" as const;

--- a/packages/examples/src/events/helpers.ts
+++ b/packages/examples/src/events/helpers.ts
@@ -1,0 +1,35 @@
+import { useNovaEventing } from "@nova/react";
+import { useCallback } from "react";
+import { events } from "./events";
+
+export const useOnDeleteFeedback = (
+  feedbackId: string,
+  feedbackText: string,
+) => {
+  const eventing = useNovaEventing();
+
+  return useCallback(
+    (reactEvent: React.SyntheticEvent) => {
+      const event = events.onDeleteFeedback({ feedbackId, feedbackText });
+      void eventing.bubble({ event, reactEvent });
+    },
+    [eventing, feedbackId, feedbackText],
+  );
+};
+
+export const useFeedbackTelemetry = () => {
+  const eventing = useNovaEventing();
+
+  return useCallback(
+    (
+      operation:
+        | "FeedbackLiked"
+        | "FeedbackUnliked"
+        | "FeedbackComponentUnmounted",
+    ) => {
+      const event = events.feedbackTelemetry({ operation });
+      void eventing.generateEvent({ event });
+    },
+    [eventing],
+  );
+};

--- a/packages/examples/src/relay/Feedback/Feedback.test.tsx
+++ b/packages/examples/src/relay/Feedback/Feedback.test.tsx
@@ -5,11 +5,45 @@ import * as React from "react";
 import "@testing-library/jest-dom";
 import { executePlayFunction } from "../../testing-utils/executePlayFunction";
 import { prepareStoryContextForTest } from "@nova/react-test-utils/relay";
+import type { NovaEventing, EventWrapper } from "@nova/types";
 
-const { ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError } =
+const { ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError, Primary } =
   composeStories(stories);
 
+const bubbleMock = jest.fn<NovaEventing, [EventWrapper]>();
+const generateEventMock = jest.fn<NovaEventing, [EventWrapper]>();
+
+jest.mock("@nova/react", () => ({
+  ...jest.requireActual("@nova/react"),
+  useNovaEventing: () => ({
+    bubble: bubbleMock,
+    generateEvent: generateEventMock,
+  }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe("Feedback", () => {
+  it("rerenders without unmounting", async () => {
+    const { rerender, findByRole } = render(<Primary />);
+    await findByRole("button", { name: "Like" });
+
+    let telemetryEvents = generateEventMock.mock.calls.filter(
+      ([{ event }]) => event.type === "feedbackTelemetry",
+    );
+
+    expect(telemetryEvents).toHaveLength(1); // coming from strict mode
+
+    rerender(<Primary />);
+    await findByRole("button", { name: "Like" });
+
+    telemetryEvents = generateEventMock.mock.calls.filter(
+      ([{ event }]) => event.type === "feedbackTelemetry",
+    );
+    expect(telemetryEvents).toHaveLength(1); // there are no remounts of the component on Story rerender
+  });
   it("throws an error when the developer makes a mistake", async () => {
     const { container } = render(
       <ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError />,

--- a/packages/examples/src/relay/Feedback/Feedback.tsx
+++ b/packages/examples/src/relay/Feedback/Feedback.tsx
@@ -1,13 +1,11 @@
-import {
-  graphql,
-  useFragment,
-  useMutation,
-  useNovaEventing,
-} from "@nova/react";
+import { graphql, useFragment, useMutation } from "@nova/react";
 import * as React from "react";
 import type { FeedbackComponent_LikeMutation } from "./__generated__/FeedbackComponent_LikeMutation.graphql";
 import type { Feedback_feedbackFragment$key } from "./__generated__/Feedback_feedbackFragment.graphql";
-import { events } from "../../events/events";
+import {
+  useOnDeleteFeedback,
+  useFeedbackTelemetry,
+} from "../../events/helpers";
 
 type Props = {
   feedback: Feedback_feedbackFragment$key;
@@ -45,6 +43,12 @@ export const FeedbackComponent = (props: Props) => {
   );
 
   const feedbackTelemetry = useFeedbackTelemetry();
+
+  React.useEffect(() => {
+    return () => {
+      feedbackTelemetry("FeedbackComponentUnmounted");
+    };
+  }, []);
 
   return (
     <div
@@ -94,29 +98,5 @@ export const FeedbackComponent = (props: Props) => {
       </button>
       <button onClick={onDeleteFeedback}>Delete feedback</button>
     </div>
-  );
-};
-
-const useOnDeleteFeedback = (feedbackId: string, feedbackText: string) => {
-  const eventing = useNovaEventing();
-
-  return React.useCallback(
-    (reactEvent: React.SyntheticEvent) => {
-      const event = events.onDeleteFeedback({ feedbackId, feedbackText });
-      void eventing.bubble({ event, reactEvent });
-    },
-    [eventing, feedbackId, feedbackText],
-  );
-};
-
-const useFeedbackTelemetry = () => {
-  const eventing = useNovaEventing();
-
-  return React.useCallback(
-    (operation: "FeedbackLiked" | "FeedbackUnliked") => {
-      const event = events.feedbackTelemetry({ operation });
-      void eventing.generateEvent({ event });
-    },
-    [eventing],
   );
 };

--- a/packages/examples/src/relay/pure-relay/Feedback.test.tsx
+++ b/packages/examples/src/relay/pure-relay/Feedback.test.tsx
@@ -5,13 +5,48 @@ import * as React from "react";
 import "@testing-library/jest-dom";
 import { executePlayFunction } from "../../testing-utils/executePlayFunction";
 import { prepareStoryContextForTest } from "@nova/react-test-utils/relay";
+import type { NovaEventing, EventWrapper } from "@nova/types";
 
 const {
   ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError,
   LikeFailure,
+  Primary,
 } = composeStories(stories);
 
+const bubbleMock = jest.fn<NovaEventing, [EventWrapper]>();
+const generateEventMock = jest.fn<NovaEventing, [EventWrapper]>();
+
+jest.mock("@nova/react", () => ({
+  ...jest.requireActual("@nova/react"),
+  useNovaEventing: () => ({
+    bubble: bubbleMock,
+    generateEvent: generateEventMock,
+  }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
 describe("Feedback", () => {
+  it("rerenders without unmounting", async () => {
+    const { rerender, findByRole } = render(<Primary />);
+    await findByRole("button", { name: "Like" });
+
+    let telemetryEvents = generateEventMock.mock.calls.filter(
+      ([{ event }]) => event.type === "feedbackTelemetry",
+    );
+
+    expect(telemetryEvents).toHaveLength(1); // coming from strict mode
+
+    rerender(<Primary />);
+    await findByRole("button", { name: "Like" });
+
+    telemetryEvents = generateEventMock.mock.calls.filter(
+      ([{ event }]) => event.type === "feedbackTelemetry",
+    );
+    expect(telemetryEvents).toHaveLength(1); // there are no remounts of the component on Story rerender
+  });
   it("should show an error if the like button fails", async () => {
     const { container } = render(<LikeFailure />);
     await executePlayFunction(

--- a/packages/examples/src/relay/pure-relay/Feedback.tsx
+++ b/packages/examples/src/relay/pure-relay/Feedback.tsx
@@ -1,9 +1,11 @@
 import { graphql, useFragment, useMutation } from "react-relay";
-import { useNovaEventing } from "@nova/react";
 import * as React from "react";
 import type { FeedbackComponent_RelayLikeMutation } from "./__generated__/FeedbackComponent_RelayLikeMutation.graphql";
 import type { Feedback_feedbackRelayFragment$key } from "./__generated__/Feedback_feedbackRelayFragment.graphql";
-import { events } from "../../events/events";
+import {
+  useOnDeleteFeedback,
+  useFeedbackTelemetry,
+} from "../../events/helpers";
 
 type Props = {
   feedback: Feedback_feedbackRelayFragment$key;
@@ -41,6 +43,12 @@ export const FeedbackComponent = (props: Props) => {
   );
 
   const feedbackTelemetry = useFeedbackTelemetry();
+
+  React.useEffect(() => {
+    return () => {
+      feedbackTelemetry("FeedbackComponentUnmounted");
+    };
+  }, []);
 
   return (
     <div
@@ -91,29 +99,5 @@ export const FeedbackComponent = (props: Props) => {
       </button>
       <button onClick={onDeleteFeedback}>Delete feedback</button>
     </div>
-  );
-};
-
-const useOnDeleteFeedback = (feedbackId: string, feedbackText: string) => {
-  const eventing = useNovaEventing();
-
-  return React.useCallback(
-    (reactEvent: React.SyntheticEvent) => {
-      const event = events.onDeleteFeedback({ feedbackId, feedbackText });
-      void eventing.bubble({ event, reactEvent });
-    },
-    [eventing, feedbackId, feedbackText],
-  );
-};
-
-const useFeedbackTelemetry = () => {
-  const eventing = useNovaEventing();
-
-  return React.useCallback(
-    (operation: "FeedbackLiked" | "FeedbackUnliked") => {
-      const event = events.feedbackTelemetry({ operation });
-      void eventing.generateEvent({ event });
-    },
-    [eventing],
   );
 };


### PR DESCRIPTION
While testing the new decorator in 1JS we discovered that when the `rerender` from React Testing Library is used, fragment based components, powered by decorator get remounted instead of rerendered. The reason was lack of stable identity for the `Renderer` function in shared decorator. In scope of this PR we refactor it to proper component, which gets us the stable identity and no remounts.

The important change is in `nova-react-test-utils`, rest are tests for the scenario which would fail before this change