### PR TITLE
chore(nova-react-test-utils): refactor for better dependency split

### DIFF
--- a/change/@nova-react-test-utils-55f4b155-fca4-4dfe-96f2-cfbe183a4fe1.json
+++ b/change/@nova-react-test-utils-55f4b155-fca4-4dfe-96f2-cfbe183a4fe1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor for better dependency separation",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/package.json
+++ b/packages/nova-react-test-utils/package.json
@@ -52,6 +52,10 @@
     "@types/react-relay": {
       "optional": true,
       "reason": "This package is only required if you are using Relay as your GraphQL client."
+    },
+    "@types/relay-test-utils": {
+      "optional": true,
+      "reason": "This package is only required if you are using Relay as your GraphQL client."
     }
   },
   "dependencies": {
@@ -62,7 +66,6 @@
     "@nova/types": "^1.5.1",
     "@types/react": "^17 || ^18",
     "@types/relay-runtime": ">16",
-    "@types/relay-test-utils": ">16",
     "graphql": "^15.5.0",
     "invariant": "^2.2.4",
     "tslib": "^2.2.0",
@@ -79,6 +82,7 @@
     "@testing-library/react": "^15.0.0",
     "@types/jest": "^29.2.0",
     "@types/react-relay": "^16.0.0",
+    "@types/relay-test-utils": "^17.0.0",
     "@types/react-test-renderer": "^18.3.0",
     "monorepo-scripts": "*",
     "react": "^18.3.1",
@@ -96,19 +100,13 @@
   "access": "public",
   "exports": {
     ".": {
-      "import": "./lib/relay/index.mjs",
-      "require": "./lib/relay/index.js",
-      "types": "./lib/relay/index.d.ts"
+      "import": "./src/relay/index.ts"
     },
     "./relay": {
-      "import": "./lib/relay/index.mjs",
-      "require": "./lib/relay/index.js",
-      "types": "./lib/relay/index.d.ts"
+      "import": "./src/relay/index.ts"
     },
     "./apollo": {
-      "import": "./lib/apollo/index.mjs",
-      "require": "./lib/apollo/index.js",
-      "types": "./lib/apollo/index.d.ts"
+      "import": "./src/apollo/index.ts"
     }
   },
   "publishConfig": {

--- a/packages/nova-react-test-utils/package.json
+++ b/packages/nova-react-test-utils/package.json
@@ -100,13 +100,16 @@
   "access": "public",
   "exports": {
     ".": {
-      "import": "./src/relay/index.ts"
+      "import": "./src/relay/index.ts",
+      "require": "./lib/relay/index.js"
     },
     "./relay": {
-      "import": "./src/relay/index.ts"
+      "import": "./src/relay/index.ts",
+      "require": "./lib/relay/index.js"
     },
     "./apollo": {
-      "import": "./src/apollo/index.ts"
+      "import": "./src/apollo/index.ts",
+      "require": "./lib/apollo/index.js"
     }
   },
   "publishConfig": {

--- a/packages/nova-react-test-utils/src/apollo/index.ts
+++ b/packages/nova-react-test-utils/src/apollo/index.ts
@@ -1,5 +1,5 @@
-export { NovaMockEnvironmentProvider } from "../shared/nova-mock-environment";
-export type { NovaMockEnvironment } from "../shared/nova-mock-environment";
+export { NovaMockEnvironmentProvider } from "./nova-mock-environment";
+export type { NovaMockEnvironment } from "./nova-mock-environment";
 export { prepareStoryContextForTest } from "../shared/storybook-nova-decorator-shared";
 export type {
   WithNovaEnvironment,

--- a/packages/nova-react-test-utils/src/apollo/nova-mock-environment.tsx
+++ b/packages/nova-react-test-utils/src/apollo/nova-mock-environment.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import {
+  type NovaMockEnvironment as GenericNovaMockEnvironment,
+  NovaMockEnvironmentProvider as GenericNovaMockEnvironmentProvider,
+  type NovaMockEnvironmentProviderProps,
+} from "../shared/nova-mock-environment";
+import type { NovaGraphQL } from "@nova/types";
+import type { MockFunctions } from "@graphitation/apollo-mock-client";
+import type { Environment } from "../shared/shared-utils";
+import type { GraphQLTaggedNode } from "@nova/react";
+
+type ApolloNovaGraphQL = NovaGraphQL & {
+  mock: MockFunctions<unknown, GraphQLTaggedNode>;
+};
+
+export type NovaMockEnvironment<T extends Environment = "test"> =
+  GenericNovaMockEnvironment<T, ApolloNovaGraphQL> & { type: "apollo" };
+
+export const NovaMockEnvironmentProvider = <T extends Environment = "test">({
+  children,
+  environment,
+}: React.PropsWithChildren<
+  NovaMockEnvironmentProviderProps<T, ApolloNovaGraphQL>
+>) => {
+  return (
+    <GenericNovaMockEnvironmentProvider environment={environment}>
+      {children}
+    </GenericNovaMockEnvironmentProvider>
+  );
+};

--- a/packages/nova-react-test-utils/src/apollo/storybook-nova-decorator-apollo.tsx
+++ b/packages/nova-react-test-utils/src/apollo/storybook-nova-decorator-apollo.tsx
@@ -1,4 +1,3 @@
-import type { NovaMockEnvironment } from "../shared/nova-mock-environment";
 import { ApolloMockPayloadGenerator } from "./test-utils";
 import type { GraphQLSchema } from "graphql";
 import * as React from "react";
@@ -16,6 +15,7 @@ import type { MakeDecoratorResult } from "../shared/shared-utils";
 import { defaultTrigger, defaultBubble } from "../shared/shared-utils";
 import type { ReactRenderer } from "@storybook/react";
 import type { PlayFunctionContext } from "@storybook/types";
+import type { NovaMockEnvironment } from "./nova-mock-environment";
 
 type MockClientOptions = Parameters<typeof createMockClient>[1];
 
@@ -30,7 +30,7 @@ export const getNovaApolloDecorator: (
   const createEnvironment = () => createNovaEnvironment(schema, rest);
   const initializeGenerator = (
     parameters: WithNovaEnvironment["novaEnvironment"],
-    environment: NovaMockEnvironment<"apollo", "storybook">,
+    environment: NovaMockEnvironment<"storybook">,
   ) => {
     const mockResolvers = parameters?.resolvers;
     const generate = generateFunction ?? ApolloMockPayloadGenerator.generate;
@@ -46,9 +46,9 @@ export const getNovaApolloDecorator: (
 function createNovaEnvironment(
   schema: GraphQLSchema,
   options?: MockClientOptions,
-): NovaMockEnvironment<"apollo", "storybook"> {
+): NovaMockEnvironment<"storybook"> {
   const client = createMockClient(schema, options);
-  const env: NovaMockEnvironment<"apollo", "storybook"> = {
+  const env: NovaMockEnvironment<"storybook"> = {
     type: "apollo",
     graphql: {
       ...(GraphQLHooks as NovaGraphQL),
@@ -69,10 +69,16 @@ function createNovaEnvironment(
 
 export const getNovaApolloEnvironmentForStory = (
   context: PlayFunctionContext<ReactRenderer>,
-): NovaMockEnvironment<"apollo", "storybook"> => {
+): NovaMockEnvironment<"storybook"> => {
   const env = getNovaEnvironmentForStory(context);
-  if (env.type !== "apollo") {
+  if (!isApolloEnvironment(env)) {
     throw new Error("Expected relay environment to be present on context");
   }
   return env;
+};
+
+const isApolloEnvironment = (
+  env: ReturnType<typeof getNovaEnvironmentForStory>,
+): env is NovaMockEnvironment<"storybook"> => {
+  return env.type === "apollo";
 };

--- a/packages/nova-react-test-utils/src/apollo/test-utils.tsx
+++ b/packages/nova-react-test-utils/src/apollo/test-utils.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { NovaMockEnvironment } from "../shared/nova-mock-environment";
 import { ApolloProvider } from "@apollo/client";
 import type { GraphQLSchema } from "graphql";
 import type { MockFunctions } from "@graphitation/apollo-mock-client";
@@ -9,6 +8,7 @@ import type { OperationDescriptor } from "@graphitation/graphql-js-operation-pay
 import { generate as payloadGenerator } from "@graphitation/graphql-js-operation-payload-generator";
 import type { GraphQLTaggedNode } from "@nova/react";
 import type { NovaGraphQL } from "@nova/types";
+import type { NovaMockEnvironment } from "./nova-mock-environment";
 
 type MockClientOptions = Parameters<typeof createMockClient>[1];
 

--- a/packages/nova-react-test-utils/src/apollo/utils.test.tsx
+++ b/packages/nova-react-test-utils/src/apollo/utils.test.tsx
@@ -4,10 +4,18 @@ import type { ReactTestRenderer } from "react-test-renderer";
 import { act, create as createTestRenderer } from "react-test-renderer";
 import type { EntityCommand, EventWrapper } from "@nova/types";
 import { graphql, useLazyLoadQuery } from "@nova/react";
-import { createNovaApolloEnvironment, ApolloMockPayloadGenerator } from "./test-utils";
-import type { NovaMockEnvironment } from "../shared/nova-mock-environment";
-import { NovaMockEnvironmentProvider } from "../shared/nova-mock-environment";
-import { getApolloOperationName, getApolloOperationType } from "./operation-utils";
+import {
+  createNovaApolloEnvironment,
+  ApolloMockPayloadGenerator,
+} from "./test-utils";
+import {
+  getApolloOperationName,
+  getApolloOperationType,
+} from "./operation-utils";
+import {
+  type NovaMockEnvironment,
+  NovaMockEnvironmentProvider,
+} from "./nova-mock-environment";
 
 const schema = buildASTSchema(
   parse(`
@@ -116,7 +124,9 @@ describe(createNovaApolloEnvironment, () => {
       });
 
       expect(
-        getApolloOperationName(environment.graphql.mock.getMostRecentOperation()),
+        getApolloOperationName(
+          environment.graphql.mock.getMostRecentOperation(),
+        ),
       ).toEqual("MockTestQuery");
     });
 
@@ -130,7 +140,9 @@ describe(createNovaApolloEnvironment, () => {
       });
 
       expect(
-        getApolloOperationType(environment.graphql.mock.getMostRecentOperation()),
+        getApolloOperationType(
+          environment.graphql.mock.getMostRecentOperation(),
+        ),
       ).toEqual("query");
     });
   });

--- a/packages/nova-react-test-utils/src/relay/index.ts
+++ b/packages/nova-react-test-utils/src/relay/index.ts
@@ -1,5 +1,5 @@
-export { NovaMockEnvironmentProvider } from "../shared/nova-mock-environment";
-export type { NovaMockEnvironment } from "../shared/nova-mock-environment";
+export { NovaMockEnvironmentProvider } from "./nova-mock-environment";
+export type { NovaMockEnvironment } from "./nova-mock-environment";
 export { prepareStoryContextForTest } from "../shared/storybook-nova-decorator-shared";
 export type {
   WithNovaEnvironment,

--- a/packages/nova-react-test-utils/src/relay/nova-mock-environment.tsx
+++ b/packages/nova-react-test-utils/src/relay/nova-mock-environment.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import {
+  type NovaMockEnvironment as GenericNovaMockEnvironment,
+  NovaMockEnvironmentProvider as GenericNovaMockEnvironmentProvider,
+  type NovaMockEnvironmentProviderProps,
+} from "../shared/nova-mock-environment";
+import type { NovaGraphQL } from "@nova/types";
+import type { MockEnvironment } from "relay-test-utils";
+import type { Environment } from "../shared/shared-utils";
+
+type RelayNovaGraphQL = NovaGraphQL & {
+  mock: MockEnvironment["mock"];
+};
+
+export type NovaMockEnvironment<T extends Environment = "test"> =
+  GenericNovaMockEnvironment<T, RelayNovaGraphQL> & { type: "relay" };
+
+export const NovaMockEnvironmentProvider = <T extends Environment = "test">({
+  children,
+  environment,
+}: React.PropsWithChildren<
+  NovaMockEnvironmentProviderProps<T, RelayNovaGraphQL>
+>) => {
+  return (
+    <GenericNovaMockEnvironmentProvider environment={environment}>
+      {children}
+    </GenericNovaMockEnvironmentProvider>
+  );
+};

--- a/packages/nova-react-test-utils/src/relay/storybook-nova-decorator-relay.tsx
+++ b/packages/nova-react-test-utils/src/relay/storybook-nova-decorator-relay.tsx
@@ -1,4 +1,3 @@
-import type { NovaMockEnvironment } from "../shared/nova-mock-environment";
 import {
   getDecorator,
   getNovaEnvironmentForStory,
@@ -14,6 +13,7 @@ import { createMockEnvironment } from "relay-test-utils";
 import type { GraphQLSchema } from "graphql";
 import type { ReactRenderer } from "@storybook/react";
 import type { PlayFunctionContext } from "@storybook/types";
+import type { NovaMockEnvironment } from "./nova-mock-environment";
 
 type RelayEnvironmentOptions = Parameters<typeof createMockEnvironment>[0];
 
@@ -29,7 +29,7 @@ export const getNovaRelayDecorator: (
   const relayMockPayloadGenerator = new RelayMockPayloadGenerator(schema);
   const initializeGenerator = (
     parameters: WithNovaEnvironment["novaEnvironment"],
-    environment: NovaMockEnvironment<"relay", "storybook">,
+    environment: NovaMockEnvironment<"storybook">,
   ) => {
     const mockResolvers = parameters?.resolvers;
     const generate =
@@ -46,9 +46,9 @@ export const getNovaRelayDecorator: (
 
 function createNovaRelayEnvironment(
   options?: RelayEnvironmentOptions,
-): NovaMockEnvironment<"relay", "storybook"> {
+): NovaMockEnvironment<"storybook"> {
   const relayEnvironment = createMockEnvironment(options);
-  const env: NovaMockEnvironment<"relay", "storybook"> = {
+  const env: NovaMockEnvironment<"storybook"> = {
     type: "relay",
     graphql: {
       ...novaGraphql,
@@ -73,10 +73,14 @@ function createNovaRelayEnvironment(
 
 export const getNovaRelayEnvironmentForStory = (
   context: PlayFunctionContext<ReactRenderer>,
-): NovaMockEnvironment<"relay", "storybook"> => {
+): NovaMockEnvironment<"storybook"> => {
   const env = getNovaEnvironmentForStory(context);
-  if (env.type !== "relay") {
+  if (!isRelayMockEnv(env)) {
     throw new Error("Expected relay environment to be present on context");
   }
   return env;
 };
+
+const isRelayMockEnv = (
+  env: ReturnType<typeof getNovaEnvironmentForStory>,
+): env is NovaMockEnvironment<"storybook"> => env.type === "relay";

--- a/packages/nova-react-test-utils/src/relay/test-utils.tsx
+++ b/packages/nova-react-test-utils/src/relay/test-utils.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import type { NovaMockEnvironment } from "../shared/nova-mock-environment";
 import { type GraphQLSchema, parse as parseGraphQL } from "graphql";
 import {
   type MockResolvers,
@@ -9,6 +8,7 @@ import type { OperationDescriptor as RelayOperationDescriptor } from "relay-runt
 import { novaGraphql } from "./nova-relay-graphql";
 import { createMockEnvironment } from "relay-test-utils";
 import { RelayEnvironmentProvider } from "react-relay";
+import type { NovaMockEnvironment } from "./nova-mock-environment";
 
 export class RelayMockPayloadGenerator {
   public gqlSchema: GraphQLSchema;
@@ -54,7 +54,7 @@ export function createNovaRelayMockEnvironment(
   options?: RelayEnvironmentOptions,
 ) {
   const relayEnvironment = createMockEnvironment(options);
-  const env: NovaMockEnvironment<"relay", "test"> = {
+  const env: NovaMockEnvironment<"test"> = {
     commanding: {
       trigger: jest.fn(),
     },

--- a/packages/nova-react-test-utils/src/shared/nova-mock-environment.tsx
+++ b/packages/nova-react-test-utils/src/shared/nova-mock-environment.tsx
@@ -5,19 +5,13 @@ import type {
   NovaGraphQL,
   NovaEventing,
 } from "@nova/types";
-import type { MockFunctions as ApolloMockFunctions } from "@graphitation/apollo-mock-client";
-import type { MockEnvironment } from "relay-test-utils";
-import type { GraphQLTaggedNode } from "@nova/react";
 import {
   mapEventMetadata,
   NovaCentralizedCommandingProvider,
   NovaEventingProvider,
   NovaGraphQLProvider,
 } from "@nova/react";
-import type { Variant } from "./shared-utils";
-
-type RelayMockFunctions = MockEnvironment["mock"];
-type Environment = "test" | "storybook";
+import type { Environment, Variant } from "./shared-utils";
 
 type Commanding<T extends Environment> = T extends "test"
   ? jest.Mocked<NovaCentralizedCommanding>
@@ -27,10 +21,10 @@ type Eventing<T extends Environment> = T extends "test"
   ? jest.Mocked<NovaEventing>
   : NovaEventing;
 
-export type NovaMockEnvironment<
-  V extends Variant = "apollo",
+export interface NovaMockEnvironment<
   T extends Environment = "test",
-> = {
+  E extends NovaGraphQL = NovaGraphQL,
+> {
   commanding: Commanding<T>;
   eventing: Eventing<T>;
   /**
@@ -38,32 +32,24 @@ export type NovaMockEnvironment<
    * inject a ApolloProvider.
    */
   providerWrapper: ComponentType<PropsWithChildren>;
-} & (V extends "apollo"
-  ? {
-      type: "apollo";
-      graphql: NovaGraphQL & {
-        mock: ApolloMockFunctions<unknown, GraphQLTaggedNode>;
-      };
-    }
-  : {
-      type: "relay";
-      graphql: NovaGraphQL & { mock: RelayMockFunctions };
-    });
+  graphql: E;
+  type: Variant;
+}
 
-interface NovaMockEnvironmentProviderProps<
-  V extends Variant,
+export interface NovaMockEnvironmentProviderProps<
   T extends Environment,
+  E extends NovaGraphQL,
 > {
-  environment: NovaMockEnvironment<V, T>;
+  environment: NovaMockEnvironment<T, E>;
 }
 
 export const NovaMockEnvironmentProvider = <
-  V extends Variant = "apollo",
   T extends Environment = "test",
+  E extends NovaGraphQL = NovaGraphQL,
 >({
   children,
   environment,
-}: React.PropsWithChildren<NovaMockEnvironmentProviderProps<V, T>>) => {
+}: React.PropsWithChildren<NovaMockEnvironmentProviderProps<T, E>>) => {
   return (
     <NovaEventingProvider
       eventing={environment.eventing}

--- a/packages/nova-react-test-utils/src/shared/shared-utils.ts
+++ b/packages/nova-react-test-utils/src/shared/shared-utils.ts
@@ -4,6 +4,8 @@ import type { makeDecorator } from "@storybook/preview-api";
 
 export type Variant = "apollo" | "relay";
 
+export type Environment = "test" | "storybook";
+
 export function defaultBubble(eventWrapper: EventWrapper): Promise<void> {
   const eventData =
     typeof eventWrapper.event.data === "function"

--- a/packages/nova-react-test-utils/src/shared/storybook-nova-decorator-shared.tsx
+++ b/packages/nova-react-test-utils/src/shared/storybook-nova-decorator-shared.tsx
@@ -13,7 +13,6 @@ import type { NovaMockEnvironment } from "./nova-mock-environment";
 import { NovaMockEnvironmentProvider } from "./nova-mock-environment";
 import type { ReactRenderer } from "@storybook/react";
 import type { OperationType } from "relay-runtime";
-import type { Variant } from "./shared-utils";
 
 type Context = Parameters<Parameters<typeof makeDecorator>[0]["wrapper"]>[1];
 
@@ -103,11 +102,11 @@ const Renderer: React.FC<RendererProps> = ({
 const NAME_OF_ASSIGNED_PARAMETER_IN_DECORATOR =
   "novaEnvironmentAssignedParameterValue";
 
-export const getDecorator = <V extends Variant = "apollo">(
-  createEnvironment: () => NovaMockEnvironment<V, "storybook">,
+export const getDecorator = <E extends NovaMockEnvironment<"storybook">>(
+  createEnvironment: () => E,
   initializeGenerator: (
     parameters: WithNovaEnvironment["novaEnvironment"],
-    environment: NovaMockEnvironment<V, "storybook">,
+    environment: E,
   ) => void,
 ) => {
   return makeDecorator({
@@ -147,7 +146,7 @@ export const getNovaEnvironmentForStory = (
   context: PlayFunctionContext<ReactRenderer>,
 ) => {
   const env = context.parameters?.[NAME_OF_ASSIGNED_PARAMETER_IN_DECORATOR] as
-    | NovaMockEnvironment<Variant, "storybook">
+    | NovaMockEnvironment<"storybook">
     | undefined;
   if (!env) {
     throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,7 +3861,7 @@
   resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-17.0.4.tgz#428526fc3e6dfb6e0a5730c38ad521cb1eea189b"
   integrity sha512-fB77br4lXlBYM/HpI6VI6KCrj5pw0LiAnkZOkffjirNYso+dzXGWkeIm0G0MGszD8WY1et+r1Uj2TA6rscBXNQ==
 
-"@types/relay-test-utils@>16":
+"@types/relay-test-utils@^17.0.0":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/relay-test-utils/-/relay-test-utils-17.0.0.tgz#a427470f26f808b4962c8d0a66c2d9af25db156e"
   integrity sha512-q+Nq3RpJ4fKcRfJQTK/IvKg4cmrJkbboR8V4hxlEW5MkMTNqGCOJ4xlKagSTsLycovw3Eea6fNmmBSaMlKRwCw==


### PR DESCRIPTION
While making two versions of test utils for relay and apollo we realized it's good to separate deps and use optional peer dependencies to make consumers only install one set of deps (for apollo or relay not both). We separated most but in `shared/nova-mock-environment` we kept reference to both `@graphitation/apollo-mock-client` and `relay-test-utils`. In scope of this PR we refactor code to separate these deps out to not be in `shared` folder but only in client specific ones.


Additionally, we change the export map for local development (to refer to src files) to avoid need to build to run tests/stories locally