### PR TITLE
fix(nova-react-test-utils): replace default imports with * imports

### DIFF
--- a/change/@nova-react-f0f39448-a25c-42e0-a43f-ffbc21cef7de.json
+++ b/change/@nova-react-f0f39448-a25c-42e0-a43f-ffbc21cef7de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "change to * as imports",
+  "packageName": "@nova/react",
+  "email": "sjwilczynski@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-react-test-utils-adf668c1-9898-44c0-928f-a9e9ad6f6b79.json
+++ b/change/@nova-react-test-utils-adf668c1-9898-44c0-928f-a9e9ad6f6b79.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "change to * as imports",
+  "packageName": "@nova/react-test-utils",
+  "email": "sjwilczynski@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/src/apollo/test-utils.tsx
+++ b/packages/nova-react-test-utils/src/apollo/test-utils.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { ApolloProvider } from "@apollo/client";
 import type { GraphQLSchema } from "graphql";
 import type { MockFunctions } from "@graphitation/apollo-mock-client";

--- a/packages/nova-react-test-utils/src/apollo/utils.test.tsx
+++ b/packages/nova-react-test-utils/src/apollo/utils.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { buildASTSchema, parse } from "graphql";
 import type { ReactTestRenderer } from "react-test-renderer";
 import { act, create as createTestRenderer } from "react-test-renderer";

--- a/packages/nova-react-test-utils/src/shared/nova-mock-environment.tsx
+++ b/packages/nova-react-test-utils/src/shared/nova-mock-environment.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import type { ComponentType, PropsWithChildren } from "react";
 import type {
   NovaCentralizedCommanding,

--- a/packages/nova-react/src/commanding/nova-centralized-commanding-provider.test.tsx
+++ b/packages/nova-react/src/commanding/nova-centralized-commanding-provider.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import React from "react";
+import * as React from "react";
 import { render } from "@testing-library/react";
 import {
   NovaCentralizedCommandingProvider,

--- a/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
+++ b/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import * as React from "react";
 import type { NovaCentralizedCommanding } from "@nova/types";
-import invariant from "invariant";
+import * as invariant from "invariant";
 
 // Initializing default with null to make sure providers are correctly placed in the tree
 const NovaCommandingContext =

--- a/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import React from "react";
+import * as React from "react";
 import { render, waitFor } from "@testing-library/react";
 import type {
   GeneratedEventWrapper,

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { NovaEvent, NovaEventing, EventWrapper } from "@nova/types";
 import { InputType } from "@nova/types";
-import invariant from "invariant";
+import * as invariant from "invariant";
 
 // Context is initialized with an empty object and this is null-checked within the hooks
 const NovaEventingContext = React.createContext<INovaEventingContext>({});

--- a/packages/nova-react/src/graphql/hooks.test.tsx
+++ b/packages/nova-react/src/graphql/hooks.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import React from "react";
+import * as React from "react";
 import { render, screen, renderHook } from "@testing-library/react";
 
 import { NovaGraphQLProvider } from "./nova-graphql-provider";

--- a/packages/nova-react/src/graphql/hooks.ts
+++ b/packages/nova-react/src/graphql/hooks.ts
@@ -1,5 +1,5 @@
 import { useNovaGraphQL } from "./nova-graphql-provider";
-import invariant from "invariant";
+import * as invariant from "invariant";
 
 import type { GraphQLTaggedNode } from "./taggedNode";
 import type {
@@ -8,7 +8,7 @@ import type {
   OperationType,
   PaginationFn,
   RefetchFn,
-  FetchPolicy
+  FetchPolicy,
 } from "./types";
 
 /**

--- a/packages/nova-react/src/graphql/nova-graphql-provider.test.tsx
+++ b/packages/nova-react/src/graphql/nova-graphql-provider.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import React from "react";
+import * as React from "react";
 import type { NovaGraphQL } from "@nova/types";
 import { render } from "@testing-library/react";
 import { NovaGraphQLProvider, useNovaGraphQL } from "./nova-graphql-provider";

--- a/packages/nova-react/src/graphql/nova-graphql-provider.tsx
+++ b/packages/nova-react/src/graphql/nova-graphql-provider.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import * as React from "react";
 import type { NovaGraphQL } from "@nova/types";
-import invariant from "invariant";
+import * as invariant from "invariant";
 
 // Initializing default with null to make sure providers are correctly placed in the tree
 const NovaGraphQLContext = React.createContext<NovaGraphQL | null>(null);

--- a/scripts/config/jest.config.ts
+++ b/scripts/config/jest.config.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import * as path from "path";
 
 export default {
   preset: "ts-jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,6 @@
     "declarationMap": true,
     "strict": true,
     "skipLibCheck": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
   }


### PR DESCRIPTION
A lot of packages in 1JS need to update their tsconfig when integrating new test utils, due to default imports on `React` and `invariant`. Instead of forcing the change, we can adjust imports inside the package and remove the need of setting `esModuleInterop`. As verification, we removed that from the tsconfig in the repo itself