### PR TITLE
fix(nova/react): bring back default import for invariant

### DIFF
--- a/change/@nova-react-7777c2ef-6eb5-4013-bbf2-3d51bb071261.json
+++ b/change/@nova-react-7777c2ef-6eb5-4013-bbf2-3d51bb071261.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bring back default import for invariant",
+  "packageName": "@nova/react",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
+++ b/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { NovaCentralizedCommanding } from "@nova/types";
-import * as invariant from "invariant";
+import invariant from "invariant";
 
 // Initializing default with null to make sure providers are correctly placed in the tree
 const NovaCommandingContext =

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import type { NovaEvent, NovaEventing, EventWrapper } from "@nova/types";
 import { InputType } from "@nova/types";
-import * as invariant from "invariant";
+import invariant from "invariant";
 
 // Context is initialized with an empty object and this is null-checked within the hooks
 const NovaEventingContext = React.createContext<INovaEventingContext>({});

--- a/packages/nova-react/src/graphql/hooks.ts
+++ b/packages/nova-react/src/graphql/hooks.ts
@@ -1,5 +1,5 @@
 import { useNovaGraphQL } from "./nova-graphql-provider";
-import * as invariant from "invariant";
+import invariant from "invariant";
 
 import type { GraphQLTaggedNode } from "./taggedNode";
 import type {

--- a/packages/nova-react/src/graphql/nova-graphql-provider.tsx
+++ b/packages/nova-react/src/graphql/nova-graphql-provider.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import type { NovaGraphQL } from "@nova/types";
-import * as invariant from "invariant";
+import invariant from "invariant";
 
 // Initializing default with null to make sure providers are correctly placed in the tree
 const NovaGraphQLContext = React.createContext<NovaGraphQL | null>(null);

--- a/scripts/config/jest.config.ts
+++ b/scripts/config/jest.config.ts
@@ -1,10 +1,20 @@
 import * as path from "path";
+import type { JestConfigWithTsJest } from "ts-jest";
 
-export default {
+const config: JestConfigWithTsJest = {
   preset: "ts-jest",
   rootDir: process.cwd(),
   roots: ["<rootDir>/src"],
   testPathIgnorePatterns: ["node_modules", "__generated__"],
   testEnvironment: "jsdom",
   setupFiles: [path.join(__dirname, "jest.setup.ts")],
+  globals: {
+    "ts-jest": {
+      tsconfig: {
+        esModuleInterop: true,
+      },
+    },
+  },
 };
+
+export default config;


### PR DESCRIPTION
In #120 we replace all `import React as "react"` and all `import invariant from "invariant"` to be * imports to mitigate issues due to failures in 1JS when seeing `import React as "react"` even in ES modules. However, there were no complaints about invariant and we did change anyway. Turns out that wasn't a good idea because then when running jest in 1JS (or anywhere else were we use /lib files from facade) we get `Error: Uncaught [TypeError: invariant is not a function]` as `invariant` really has a default export which is a single function and then 
![image](https://github.com/user-attachments/assets/3ad45830-c2db-4863-9b87-bcec47640f82)
is missing .default to work :(

So to at least avoid having to set `esModuleInterop` outside of Jest, we bring back the default import for invariant but set `esModuleInterop` for tests only (which is also set in 1JS and TMP in default jest configs)