### PR TITLE
fix(nova/react): fix eventing for multiple nova event interceptors

### DIFF
--- a/change/@nova-react-198378aa-bbb8-4a24-8ce3-2d0718002e1e.json
+++ b/change/@nova-react-198378aa-bbb8-4a24-8ce3-2d0718002e1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix eventing pointer for multiple interceptors",
+  "packageName": "@nova/react",
+  "email": "carmenberndt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/README.md
+++ b/packages/nova-react/README.md
@@ -195,3 +195,5 @@ const MyComponentWrapper = () => {
 ```
 
 The `NovaEventingInterceptor` will intercept the event and if you can check it's properties to decide if is should be acted upon. If from `intercept` promise resolving to undefined is returned the event will not be passed to eventing higher up the tree. However, if to process the event further, one should return a promise resolving to the `eventWrapper` object. That also gives a possibility to alter the event and still pass it further up.
+
+You can nest as many interceptors as you need to either handle or pass events further up.

--- a/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
@@ -645,8 +645,9 @@ describe("Multiple NovaEventingInterceptors", () => {
       "toBeInterceptedInSecondInterceptor: Fire event to be intercepted",
     );
     button.click();
-    expect(callbackToBeCalledOnSecondIntercept).toHaveBeenCalled();
+
     await waitFor(() => expect(mapEventMetadataMock).toHaveBeenCalled());
+    expect(callbackToBeCalledOnSecondIntercept).toHaveBeenCalled();
     expect(bubbleMock).not.toHaveBeenCalled();
     expect(callbackToBeCalledOnFirstIntercept).not.toHaveBeenCalled();
   });
@@ -657,9 +658,10 @@ describe("Multiple NovaEventingInterceptors", () => {
       "toBeInterceptedInFirstInterceptor: Fire event without intercept",
     );
     button.click();
+
+    await waitFor(() => expect(bubbleMock).toHaveBeenCalled());
     expect(callbackToBeCalledOnSecondIntercept).not.toHaveBeenCalled();
     expect(callbackToBeCalledOnFirstIntercept).not.toHaveBeenCalled();
-    await waitFor(() => expect(bubbleMock).toHaveBeenCalled());
   });
 
   it("intercepts the event in first interceptor and does not bubble it up", async () => {
@@ -670,9 +672,8 @@ describe("Multiple NovaEventingInterceptors", () => {
     button.click();
 
     await waitFor(() => expect(bubbleMock).not.toHaveBeenCalled());
-    expect(callbackToBeCalledOnSecondIntercept).not.toHaveBeenCalled();
     await waitFor(() => expect(mapEventMetadataMock).toHaveBeenCalled());
-
+    expect(callbackToBeCalledOnSecondIntercept).not.toHaveBeenCalled();
     expect(callbackToBeCalledOnFirstIntercept).toHaveBeenCalled();
   });
 });

--- a/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.test.tsx
@@ -560,7 +560,6 @@ describe("Multiple NovaEventingInterceptors", () => {
   const evenOriginatorToBeInterceptedSecond = "toBeInterceptedSecond";
 
   const firstInterceptor = (eventWrapper: EventWrapper) => {
-    console.log("received event", eventWrapper.event.originator);
     if (eventWrapper.event.originator === evenOriginatorToBeInterceptedFirst) {
       callbackToBeCalledOnFirstIntercept();
       return Promise.resolve(undefined);
@@ -574,7 +573,6 @@ describe("Multiple NovaEventingInterceptors", () => {
       callbackToBeCalledOnSecondIntercept();
       return Promise.resolve(undefined);
     } else {
-      console.log("bubbling up event", eventWrapper.event.originator);
       return Promise.resolve(eventWrapper);
     }
   };

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -194,6 +194,39 @@ export const NovaEventingInterceptor: React.FunctionComponent<
     [],
   );
 
+  // Internal should point to eventing/unmountEventing created by the interceptor
+  const internal: InternalEventingContext = React.useMemo(
+    () =>
+      createInternalEventingContextPointingToInterceptor(
+        rootInternal,
+        interceptorRef,
+      ),
+    [interceptorRef],
+  );
+
+  const contextValue = React.useMemo(
+    () => ({
+      eventing: reactEventing,
+      unmountEventing: reactUnmountEventing,
+      internal,
+    }),
+    [reactEventing, reactUnmountEventing, internal],
+  );
+
+  return (
+    <NovaEventingContext.Provider value={contextValue}>
+      {children}
+    </NovaEventingContext.Provider>
+  );
+};
+NovaEventingInterceptor.displayName = "NovaEventingInterceptor";
+
+const createInternalEventingContextPointingToInterceptor = (
+  rootInternal: InternalEventingContext,
+  interceptorRef: React.MutableRefObject<
+    (event: EventWrapper) => Promise<EventWrapper | undefined>
+  >,
+): InternalEventingContext => {
   const eventing: NovaEventing = React.useMemo(
     () => ({
       bubble: async (eventWrapper: EventWrapper) =>
@@ -217,31 +250,12 @@ export const NovaEventingInterceptor: React.FunctionComponent<
   const eventingRef = React.useRef(eventing);
   const unmountEventingRef = React.useRef(unmountEventing);
 
-  const internal: InternalEventingContext = React.useMemo(
-    () => ({
-      ...rootInternal,
-      eventingRef,
-      unmountEventingRef,
-    }),
-    [eventingRef, unmountEventingRef],
-  );
-
-  const contextValue = React.useMemo(
-    () => ({
-      eventing: reactEventing,
-      unmountEventing: reactUnmountEventing,
-      internal,
-    }),
-    [reactEventing, reactUnmountEventing, internal],
-  );
-
-  return (
-    <NovaEventingContext.Provider value={contextValue}>
-      {children}
-    </NovaEventingContext.Provider>
-  );
+  return {
+    ...rootInternal,
+    eventingRef,
+    unmountEventingRef,
+  };
 };
-NovaEventingInterceptor.displayName = "NovaEventingInterceptor";
 
 /**
  * Used for eventing that should be triggered when the component is unmounted, such as within a useEffect cleanup function

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -194,7 +194,7 @@ export const NovaEventingInterceptor: React.FunctionComponent<
     [],
   );
 
-  // Internal should point to eventing/unmountEventing created by the interceptor
+  // Internal should point to eventing/unmountEventing created by the interceptor, so that we can nest arbitrary numbers of interceptors
   const internal: InternalEventingContext = React.useMemo(
     () =>
       createInternalEventingContextPointingToInterceptor(


### PR DESCRIPTION
When there are multiple interceptors, only the last one is called.

The interceptor is reading 'internal' which always refers to the novaEventing set by eventing provider. When setting the context in the interceptor, the same internal is used instead of creating a new one. The internal in the eventing should point to eventing/unmountEventing created by the interceptor and not the root nova eventing.