### PR TITLE
fix: follow rules of hooks

### DIFF
--- a/change/@nova-react-d004a70b-8f43-4bdf-8ec0-2e62cb34ed05.json
+++ b/change/@nova-react-d004a70b-8f43-4bdf-8ec0-2e62cb34ed05.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix hook",
+  "packageName": "@nova/react",
+  "email": "carmenberndt@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -195,11 +195,21 @@ export const NovaEventingInterceptor: React.FunctionComponent<
   );
 
   // Internal should point to eventing/unmountEventing created by the interceptor, so that we can nest arbitrary numbers of interceptors
-  const internal: InternalEventingContext =
-    useCreateInternalEventingContextPointingToInterceptor(
-      rootInternal,
-      interceptorRef,
-    );
+  const { eventing, unmountEventing } = React.useMemo(
+    () =>
+      createInternalEventingPointingToInterceptor(rootInternal, interceptorRef),
+    [],
+  );
+  const eventingRef = React.useRef(eventing);
+  const unmountEventingRef = React.useRef(unmountEventing);
+  const internal: InternalEventingContext = React.useMemo(
+    () => ({
+      ...rootInternal,
+      eventingRef,
+      unmountEventingRef,
+    }),
+    [],
+  );
 
   const contextValue = React.useMemo(
     () => ({
@@ -218,39 +228,25 @@ export const NovaEventingInterceptor: React.FunctionComponent<
 };
 NovaEventingInterceptor.displayName = "NovaEventingInterceptor";
 
-const useCreateInternalEventingContextPointingToInterceptor = (
+const createInternalEventingPointingToInterceptor = (
   rootInternal: InternalEventingContext,
   interceptorRef: React.MutableRefObject<
     (event: EventWrapper) => Promise<EventWrapper | undefined>
   >,
-): InternalEventingContext => {
-  const eventing: NovaEventing = React.useMemo(
-    () => ({
-      bubble: async (eventWrapper: EventWrapper) =>
-        getBubble(rootInternal.eventingRef, eventWrapper, interceptorRef),
-    }),
-    [],
-  );
+): { eventing: NovaEventing; unmountEventing: NovaEventing } => {
+  const eventing: NovaEventing = {
+    bubble: async (eventWrapper: EventWrapper) =>
+      getBubble(rootInternal.eventingRef, eventWrapper, interceptorRef),
+  };
 
-  const unmountEventing: NovaEventing = React.useMemo(
-    () => ({
-      bubble: async (eventWrapper: EventWrapper) =>
-        getBubble(
-          rootInternal.unmountEventingRef,
-          eventWrapper,
-          interceptorRef,
-        ),
-    }),
-    [],
-  );
-
-  const eventingRef = React.useRef(eventing);
-  const unmountEventingRef = React.useRef(unmountEventing);
+  const unmountEventing: NovaEventing = {
+    bubble: async (eventWrapper: EventWrapper) =>
+      getBubble(rootInternal.unmountEventingRef, eventWrapper, interceptorRef),
+  };
 
   return {
-    ...rootInternal,
-    eventingRef,
-    unmountEventingRef,
+    eventing,
+    unmountEventing,
   };
 };
 

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -172,7 +172,7 @@ export const NovaEventingInterceptor: React.FunctionComponent<
       },
       generateEvent: getGenerateEvent(rootInternal.eventingRef, interceptorRef),
     }),
-    [],
+    [rootInternal],
   );
 
   const reactUnmountEventing: NovaReactEventing = React.useMemo(
@@ -191,14 +191,14 @@ export const NovaEventingInterceptor: React.FunctionComponent<
         interceptorRef,
       ),
     }),
-    [],
+    [rootInternal],
   );
 
   // Internal should point to eventing/unmountEventing created by the interceptor, so that we can nest arbitrary numbers of interceptors
   const { eventing, unmountEventing } = React.useMemo(
     () =>
       createInternalEventingPointingToInterceptor(rootInternal, interceptorRef),
-    [],
+    [rootInternal],
   );
   const eventingRef = React.useRef(eventing);
   const unmountEventingRef = React.useRef(unmountEventing);
@@ -208,7 +208,7 @@ export const NovaEventingInterceptor: React.FunctionComponent<
       eventingRef,
       unmountEventingRef,
     }),
-    [],
+    [rootInternal],
   );
 
   const contextValue = React.useMemo(

--- a/packages/nova-react/src/eventing/nova-eventing-provider.tsx
+++ b/packages/nova-react/src/eventing/nova-eventing-provider.tsx
@@ -195,14 +195,11 @@ export const NovaEventingInterceptor: React.FunctionComponent<
   );
 
   // Internal should point to eventing/unmountEventing created by the interceptor, so that we can nest arbitrary numbers of interceptors
-  const internal: InternalEventingContext = React.useMemo(
-    () =>
-      createInternalEventingContextPointingToInterceptor(
-        rootInternal,
-        interceptorRef,
-      ),
-    [interceptorRef],
-  );
+  const internal: InternalEventingContext =
+    useCreateInternalEventingContextPointingToInterceptor(
+      rootInternal,
+      interceptorRef,
+    );
 
   const contextValue = React.useMemo(
     () => ({
@@ -221,7 +218,7 @@ export const NovaEventingInterceptor: React.FunctionComponent<
 };
 NovaEventingInterceptor.displayName = "NovaEventingInterceptor";
 
-const createInternalEventingContextPointingToInterceptor = (
+const useCreateInternalEventingContextPointingToInterceptor = (
   rootInternal: InternalEventingContext,
   interceptorRef: React.MutableRefObject<
     (event: EventWrapper) => Promise<EventWrapper | undefined>


### PR DESCRIPTION
The function creating internal object contains hooks, so it should not be called inside useMemo.