### PR TITLE
feat(pipelines): set persistCredentials for beachball

### DIFF
--- a/.azure-devops/nova-facade-release.yml
+++ b/.azure-devops/nova-facade-release.yml
@@ -53,6 +53,8 @@ extends:
               image: ubuntu-latest
               os: linux
             steps:
+              - checkout: self
+                persistCredentials: true # fix for beachball: https://github.com/microsoft/beachball/issues/674
               - script: yarn
                 displayName: yarn
               - script: |
@@ -61,7 +63,6 @@ extends:
               - script: |
                   git config user.email "gql-svc@microsoft.com"
                   git config user.name "Graphitation Service Account"
-                  git remote set-url origin https://gql-svc:$(ossGithubPAT)@github.com/microsoft/nova-facade.git
                 displayName: Configure git for release
               - script: yarn release -y -n $(ossNpmToken) --access public
                 displayName: Release


### PR DESCRIPTION
Do not use PAT token for our service account and use persistCredentials instead.