### PR TITLE
fix(nova/react-test-utils): fix accessing a property that doesn't exist anymore

### DIFF
--- a/change/@nova-react-test-utils-bceabead-7e25-4e73-ac90-44aa7c75de70.json
+++ b/change/@nova-react-test-utils-bceabead-7e25-4e73-ac90-44aa7c75de70.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix access to property that doens't exist anymore",
+  "packageName": "@nova/react-test-utils",
+  "email": "stwilczy@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react-test-utils/src/shared/storybook-nova-decorator-shared.tsx
+++ b/packages/nova-react-test-utils/src/shared/storybook-nova-decorator-shared.tsx
@@ -149,7 +149,7 @@ export const getNovaEnvironmentForStory = (
     | undefined;
   if (!env) {
     throw new Error(
-      `No environment found for story "${context.storyId}". Did you forget to add the "withNovaEnvironment" decorator or pass proper context to "play" function inside your unit test?`,
+      `No environment found for story "${context.id}". Did you forget to add the "withNovaEnvironment" decorator or pass proper context to "play" function inside your unit test?`,
     );
   }
   return env;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
+    "noPropertyAccessFromIndexSignature": true,
   }
 }


### PR DESCRIPTION
When we bumped Storybook in some of the previous PRs we didn't realize `storyId` property was removed from play function context. We only figured out because someone reported an issue for @nova/react-test-utils when verified types with `noPropertyAccessFromIndexSignature` set to `true`. Indeed it was undefined for all cases but I assume, no one reported it because error is showing up, only if someone messes up passing context to play function when run in unit tests. 

In scope of this PR, we add this property to our tsconfig to prevent such errors and change the value to `context.id` which is defined both in Storybook 7 and 8