### PR TITLE
feat(nova/react-tets-utils): throw an error if user has client extensions only query in relay variant

### DIFF
--- a/change/@nova-examples-47747cb9-5ddf-433f-b1b3-1a981b7afca2.json
+++ b/change/@nova-examples-47747cb9-5ddf-433f-b1b3-1a981b7afca2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add example for client only queries",
+  "packageName": "@nova/examples",
+  "email": "stwilczy@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-react-test-utils-14e2b035-68e8-4194-a665-d6471a4c4986.json
+++ b/change/@nova-react-test-utils-14e2b035-68e8-4194-a665-d6471a4c4986.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "throw error for client only queries for better DX",
+  "packageName": "@nova/react-test-utils",
+  "email": "stwilczy@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/examples/data/schema.graphql
+++ b/packages/examples/data/schema.graphql
@@ -3,6 +3,7 @@ type Mutation {
 }
 type Query {
   feedback(id: ID!): Feedback!
+  serverField: String!
 }
 
 type FeedbackLikeMutationResult {

--- a/packages/examples/src/relay/pure-relay/ViewDataOnly.stories.ts
+++ b/packages/examples/src/relay/pure-relay/ViewDataOnly.stories.ts
@@ -1,0 +1,77 @@
+import type { Meta } from "@storybook/react";
+import { getSchema } from "../../testing-utils/getSchema";
+import { graphql } from "react-relay";
+import {
+  getNovaDecorator,
+  getNovaEnvironmentForStory,
+  type WithNovaEnvironment,
+  EventingInterceptor,
+  getOperationName,
+  getOperationType,
+  type StoryObjWithoutFragmentRefs,
+} from "@nova/react-test-utils/relay";
+import { MockPayloadGenerator } from "relay-test-utils";
+import { ViewDataOnly } from "./ViewDataOnly";
+import type { TypeMap } from "../../__generated__/schema.all.interface";
+import type { ViewDataOnlyStoryRelayQuery } from "./__generated__/ViewDataOnlyStoryRelayQuery.graphql";
+
+const schema = getSchema();
+
+const novaDecorator = getNovaDecorator(schema, {
+  generateFunction: (operation, mockResolvers) => {
+    const result = MockPayloadGenerator.generate(
+      operation,
+      mockResolvers ?? null,
+      {
+        mockClientData: true,
+      },
+    );
+
+    return result;
+  },
+});
+
+const meta = {
+  component: ViewDataOnly,
+  decorators: [novaDecorator],
+  parameters: {
+    novaEnvironment: {
+      query: graphql`
+        query ViewDataOnlyStoryRelayQuery @relay_test_operation {
+          viewData {
+            ...ViewDataOnly_viewDataFragment
+          }
+        }
+      `,
+      referenceEntries: {
+        viewData: (data) => data?.viewData,
+      },
+      resolvers: {
+        ViewData: () => ({
+          viewDataField: "This is a view data field",
+        }),
+      },
+    },
+  } satisfies WithNovaEnvironment<ViewDataOnlyStoryRelayQuery, TypeMap>,
+} satisfies Meta<typeof ViewDataOnly>;
+
+export default meta;
+type Story = StoryObjWithoutFragmentRefs<typeof meta>;
+
+export const ViewDataOnlyStory: Story = {};
+
+export const ViewDataOnlyWithServerFieldSelected: Story = {
+  parameters: {
+    novaEnvironment: {
+      query: graphql`
+        query ViewDataOnlyWithServerFieldSelectedStoryRelayQuery
+        @relay_test_operation {
+          viewData {
+            ...ViewDataOnly_viewDataFragment
+          }
+          serverField
+        }
+      `,
+    },
+  },
+};

--- a/packages/examples/src/relay/pure-relay/ViewDataOnly.test.tsx
+++ b/packages/examples/src/relay/pure-relay/ViewDataOnly.test.tsx
@@ -13,7 +13,7 @@ describe("ViewDataOnly", () => {
     expect(screen.getByText(/This is a view data field/i)).toBeInTheDocument();
   });
 
-  it("throws an expcetion when only client fields are selected in test query", () => {
+  it("throws an exception when only client fields are selected in test query", () => {
     expect(() => {
       render(<ViewDataOnlyStory />);
     }).toThrowErrorMatchingInlineSnapshot(

--- a/packages/examples/src/relay/pure-relay/ViewDataOnly.test.tsx
+++ b/packages/examples/src/relay/pure-relay/ViewDataOnly.test.tsx
@@ -1,0 +1,23 @@
+import { composeStories } from "@storybook/react";
+import * as stories from "./ViewDataOnly.stories";
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import "@testing-library/jest-dom";
+
+const { ViewDataOnlyStory, ViewDataOnlyWithServerFieldSelected } =
+  composeStories(stories);
+
+describe("ViewDataOnly", () => {
+  it("renders ViewDataOnly component", () => {
+    render(<ViewDataOnlyWithServerFieldSelected />);
+    expect(screen.getByText(/This is a view data field/i)).toBeInTheDocument();
+  });
+
+  it("throws an expcetion when only client fields are selected in test query", () => {
+    expect(() => {
+      render(<ViewDataOnlyStory />);
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Client only queries are not supported in nova-react-test-utils, please add at least a single server field, otherwise mock resolvers won't be called. Addtionally if you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension. Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#pure-relay-or-nova-with-relay-how-can-i-make-sure-the-mock-data-is-generated-for-client-extensions"`,
+    );
+  });
+});

--- a/packages/examples/src/relay/pure-relay/ViewDataOnly.tsx
+++ b/packages/examples/src/relay/pure-relay/ViewDataOnly.tsx
@@ -1,0 +1,24 @@
+import { graphql } from "relay-runtime";
+import { useFragment } from "relay-hooks";
+import * as React from "react";
+import type { ViewDataOnly_viewDataFragment$key } from "./__generated__/ViewDataOnly_viewDataFragment.graphql";
+
+export const ViewDataOnly_viewDataFragment = graphql`
+  fragment ViewDataOnly_viewDataFragment on ViewData {
+    viewDataField
+  }
+`;
+
+type Props = {
+  viewData: ViewDataOnly_viewDataFragment$key;
+};
+
+export const ViewDataOnly = (props: Props) => {
+  const viewData = useFragment(ViewDataOnly_viewDataFragment, props.viewData);
+
+  return (
+    <div>
+      <p>{viewData.viewDataField}</p>
+    </div>
+  );
+};

--- a/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
+++ b/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
@@ -14,11 +14,7 @@ const useMutation: NovaGraphQL<ConcreteRequest>["useMutation"] = (document) => {
   const [mutationFn, areMutationsInFlight] = useRelayMutation(document);
 
   return [
-    ({
-      variables,
-      optimisticResponse,
-      onCompleted,
-    }) => {
+    ({ variables, optimisticResponse, onCompleted }) => {
       const relayCompatibleOptimisticResponse =
         typeof optimisticResponse === "object"
           ? optimisticResponse ?? undefined
@@ -52,6 +48,13 @@ export const novaGraphql: Required<NovaGraphQL<ConcreteRequest>> = {
     variables: Variables,
     options,
   ) => {
+    if (isClientOnlyQuery(document)) {
+      throw new Error(
+        "Client only queries are not supported in nova-react-test-utils, please add at least a single server field, otherwise mock resolvers won't be called." +
+          " Addtionally if you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension." +
+          " Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#pure-relay-or-nova-with-relay-how-can-i-make-sure-the-mock-data-is-generated-for-client-extensions",
+      );
+    }
     return {
       data: useLazyLoadQuery(document, variables, options),
       error: undefined,
@@ -62,4 +65,10 @@ export const novaGraphql: Required<NovaGraphQL<ConcreteRequest>> = {
   useRefetchableFragment,
   useSubscription,
   useMutation,
+};
+
+const isClientOnlyQuery = (document: ConcreteRequest) => {
+  const queryText = document.params.text;
+
+  return queryText === null;
 };


### PR DESCRIPTION
Multiple users in 1JS complained that it is hard to figure out why mock data is not being generated in certain cases and specified resolvers are not even executed. Turns out it was because in Relay client extensions only queries don't even reach "server" resolvers so there is nothing to generate, check facebook/relay#4927.

To make it less confusing for our devs, until we have either a fix in relay or graphitation payload generator supporting client extensions, let's throw an informative error, to let devs know what they should do.