### PR TITLE
chore: deps bump + extract shared types

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "plugins": ["prettier-plugin-packagejson"]
 }

--- a/change/@nova-examples-52b60f9d-747f-4141-8898-420bddb293f0.json
+++ b/change/@nova-examples-52b60f9d-747f-4141-8898-420bddb293f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix usage of nova params and schema",
+  "packageName": "@nova/examples",
+  "email": "sjwilczynski@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-graphql-compiler-d188842b-f101-40f3-b8f4-df334323b91e.json
+++ b/change/@nova-graphql-compiler-d188842b-f101-40f3-b8f4-df334323b91e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "prettify",
+  "packageName": "@nova/graphql-compiler",
+  "email": "sjwilczynski@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@nova-react-4b7bb569-1d54-44d9-bd1b-0b16fc8e7260.json
+++ b/change/@nova-react-4b7bb569-1d54-44d9-bd1b-0b16fc8e7260.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "prettify",
+  "packageName": "@nova/react",
+  "email": "sjwilczynski@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@nova-react-test-utils-2ed2f809-b36e-44d0-9974-73c7b4454b57.json
+++ b/change/@nova-react-test-utils-2ed2f809-b36e-44d0-9974-73c7b4454b57.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "prettify",
+  "packageName": "@nova/react-test-utils",
+  "email": "sjwilczynski@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@nova-types-de6b4b2f-2908-4776-9f4b-2b8fd4537552.json
+++ b/change/@nova-types-de6b4b2f-2908-4776-9f4b-2b8fd4537552.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "prettify",
+  "packageName": "@nova/types",
+  "email": "sjwilczynski@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -8,25 +8,26 @@
     ]
   },
   "scripts": {
-    "clean": "git clean -fdx -e node_modules",
-    "build": "lage build",
-    "types": "lage types",
-    "test": "lage test",
-    "lint": "lage lint",
-    "lage": "lage",
-    "prepare": "lage prepare",
-    "ci": "yarn lage build types test lint && yarn checkchange",
     "beachball": "beachball -b origin/main",
+    "build": "lage build",
     "change": "yarn beachball change",
     "checkchange": "yarn beachball check",
-    "release": "yarn beachball publish"
-  },
-  "devDependencies": {
-    "beachball": "2.31.12",
-    "lage": "2.7.15",
-    "prettier": "^2.8.1"
+    "ci": "yarn lage build types test lint && yarn checkchange",
+    "clean": "git clean -fdx -e node_modules",
+    "lage": "lage",
+    "lint": "lage lint",
+    "prepare": "lage prepare",
+    "release": "yarn beachball publish",
+    "test": "lage test",
+    "types": "lage types"
   },
   "resolutions": {
     "**/relay-compiler-language-graphitation/typescript": "<5"
+  },
+  "devDependencies": {
+    "beachball": "2.31.12",
+    "lage": "2.14.0",
+    "prettier": "^3.5.0",
+    "prettier-plugin-packagejson": "^2.5.0"
   }
 }

--- a/packages/examples/.storybook/main.ts
+++ b/packages/examples/.storybook/main.ts
@@ -7,7 +7,7 @@ const config: StorybookConfig = {
     getAbsolutePath("@storybook/addon-links"),
     getAbsolutePath("@storybook/addon-essentials"),
     getAbsolutePath("@storybook/addon-interactions"),
-    getAbsolutePath("@storybook/addon-webpack5-compiler-swc")
+    getAbsolutePath("@storybook/addon-webpack5-compiler-swc"),
   ],
   framework: {
     name: getAbsolutePath("@storybook/react-webpack5"),

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,20 +1,21 @@
 {
   "name": "@nova/examples",
-  "license": "MIT",
   "version": "1.7.3",
+  "license": "MIT",
+  "sideEffects": false,
   "main": "./src/index.ts",
   "scripts": {
     "build": "monorepo-scripts build",
+    "build-storybook": "storybook build",
     "generate": "graphql-codegen --config codegen.yml && yarn generate:apollo && yarn generate:relay",
     "generate:apollo": "nova-graphql-compiler --schema ./data/schema.graphql --src ./src/apollo --watchman false",
     "generate:relay": "relay-compiler",
+    "just": "monorepo-scripts",
     "lint": "monorepo-scripts lint",
     "prepare": "yarn generate",
-    "test": "monorepo-scripts test",
-    "types": "monorepo-scripts types",
-    "just": "monorepo-scripts",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "test": "monorepo-scripts test",
+    "types": "monorepo-scripts types"
   },
   "dependencies": {
     "@nova/graphql-compiler": "1.0.2",
@@ -58,18 +59,17 @@
     "storybook": "^8.4.5",
     "typescript": "^5.6.0"
   },
-  "sideEffects": false,
-  "access": "public",
   "publishConfig": {
-    "main": "./lib/index",
-    "types": "./lib/index.d.ts",
-    "module": "./lib/index.mjs",
     "exports": {
       ".": {
         "types": "./lib/index.d.ts",
         "import": "./lib/index.mjs",
         "require": "./lib/index.js"
       }
-    }
-  }
+    },
+    "main": "./lib/index",
+    "module": "./lib/index.mjs",
+    "types": "./lib/index.d.ts"
+  },
+  "access": "public"
 }

--- a/packages/examples/src/apollo/Feedback/Feedback.stories.tsx
+++ b/packages/examples/src/apollo/Feedback/Feedback.stories.tsx
@@ -8,16 +8,18 @@ import {
 } from "@nova/react-test-utils/apollo";
 import type { Meta } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "@storybook/test";
-import { getSchema } from "../../testing-utils/getSchema";
+import { schema } from "../../testing-utils/schema";
 import type { TypeMap } from "../../__generated__/schema.all.interface";
 import { FeedbackComponent, Feedback_feedbackFragment } from "./Feedback";
 import type { FeedbackStoryQuery } from "./__generated__/FeedbackStoryQuery.graphql";
 import * as React from "react";
 import type { events } from "../../events/events";
 
+type NovaParameters = WithNovaEnvironment<FeedbackStoryQuery, TypeMap>;
+
 const meta = {
   component: FeedbackComponent,
-  decorators: [getNovaDecorator(getSchema())],
+  decorators: [getNovaDecorator(schema)],
   parameters: {
     novaEnvironment: {
       query: graphql`
@@ -33,7 +35,7 @@ const meta = {
         feedback: (data) => data?.feedback,
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+  } satisfies NovaParameters,
 } satisfies Meta<typeof FeedbackComponent>;
 
 export default meta;
@@ -48,7 +50,7 @@ export const Primary: Story = {
         Feedback: () => sampleFeedback,
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 export const Liked: Story = {
@@ -61,7 +63,7 @@ export const Liked: Story = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 export const Like: Story = {
@@ -77,7 +79,7 @@ export const Like: Story = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+  } satisfies NovaParameters,
   play: async (context) => {
     const container = within(context.canvasElement);
     const likeButton = await container.findByRole("button", { name: "Like" });
@@ -93,7 +95,7 @@ export const ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError
       novaEnvironment: {
         enableQueuedMockResolvers: false,
       },
-    } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+    } satisfies NovaParameters,
     play: async (context) => {
       const {
         graphql: { mock },

--- a/packages/examples/src/apollo/Feedback/Feedback.tsx
+++ b/packages/examples/src/apollo/Feedback/Feedback.tsx
@@ -24,18 +24,16 @@ export const Feedback_feedbackFragment = graphql`
 export const FeedbackComponent = (props: Props) => {
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const feedback = useFragment(Feedback_feedbackFragment, props.feedback);
-  const [like, isPending] = useMutation<FeedbackComponent_LikeMutation>(
-    graphql`
-      mutation FeedbackComponent_LikeMutation($input: FeedbackLikeInput!) {
-        feedbackLike(input: $input) {
-          feedback {
-            id
-            doesViewerLike
-          }
+  const [like, isPending] = useMutation<FeedbackComponent_LikeMutation>(graphql`
+    mutation FeedbackComponent_LikeMutation($input: FeedbackLikeInput!) {
+      feedbackLike(input: $input) {
+        feedback {
+          id
+          doesViewerLike
         }
       }
-    `,
-  );
+    }
+  `);
   const onDeleteFeedback = useOnDeleteFeedback(
     feedback.id,
     feedback.message.text,

--- a/packages/examples/src/apollo/Feedback/FeedbackContainer.stories.ts
+++ b/packages/examples/src/apollo/Feedback/FeedbackContainer.stories.ts
@@ -7,11 +7,11 @@ import {
   MockPayloadGenerator,
   getNovaEnvironmentForStory,
 } from "@nova/react-test-utils/apollo";
-import { getSchema } from "../../testing-utils/getSchema";
+import { schema } from "../../testing-utils/schema";
 import type { TypeMap } from "../../__generated__/schema.all.interface";
 import { FeedbackContainer } from "./FeedbackContainer";
 
-const schema = getSchema();
+type NovaParameters = WithNovaEnvironment<UnknownOperation, TypeMap>;
 
 const meta = {
   component: FeedbackContainer,
@@ -30,7 +30,7 @@ export const Primary: Story = {
         Feedback: () => sampleFeedback,
       },
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 export const Liked: Story = {
@@ -43,7 +43,7 @@ export const Liked: Story = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 export const Like: Story = {
@@ -59,7 +59,7 @@ export const Like: Story = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
   play: async ({ canvasElement }) => {
     const container = within(canvasElement);
     const likeButton = await container.findByRole("button", { name: "Like" });
@@ -72,7 +72,7 @@ export const LikeFailure: Story = {
     novaEnvironment: {
       enableQueuedMockResolvers: false,
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
   play: async (context) => {
     const {
       graphql: { mock },
@@ -103,7 +103,7 @@ export const QueryFailure: Story = {
     novaEnvironment: {
       enableQueuedMockResolvers: false,
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
   play: async (context) => {
     const {
       graphql: { mock },
@@ -121,7 +121,7 @@ export const Loading: Story = {
     novaEnvironment: {
       enableQueuedMockResolvers: false,
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 const sampleFeedback = {

--- a/packages/examples/src/relay/Feedback/Feedback.stories.tsx
+++ b/packages/examples/src/relay/Feedback/Feedback.stories.tsx
@@ -1,23 +1,23 @@
-import { graphql } from "@nova/react";
+import { graphql } from "react-relay";
 import {
   getNovaDecorator,
   getNovaEnvironmentForStory,
-  MockPayloadGenerator as PayloadGenerator,
-  type StoryObjWithoutFragmentRefs,
   type WithNovaEnvironment,
+  type StoryObjWithoutFragmentRefs,
+  MockPayloadGenerator as PayloadGenerator,
   EventingInterceptor,
 } from "@nova/react-test-utils/relay";
 import type { Meta } from "@storybook/react";
 import { userEvent, waitFor, within, expect } from "@storybook/test";
+import { schema } from "../../testing-utils/schema";
 import type { TypeMap } from "../../__generated__/schema.all.interface";
 import { FeedbackComponent } from "./Feedback";
 import type { FeedbackStoryQuery } from "./__generated__/FeedbackStoryQuery.graphql";
-import { getSchema } from "../../testing-utils/getSchema";
 import * as React from "react";
 import type { events } from "../../events/events";
 import { RecordSource, Store } from "relay-runtime";
 
-const schema = getSchema();
+type NovaParameters = WithNovaEnvironment<FeedbackStoryQuery, TypeMap>;
 
 const MockPayloadGenerator = new PayloadGenerator(schema);
 
@@ -44,7 +44,7 @@ const meta = {
         feedback: (data) => data?.feedback,
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+  } satisfies NovaParameters,
 } satisfies Meta<typeof FeedbackComponent>;
 
 export default meta;
@@ -59,7 +59,7 @@ export const Primary: Story = {
         Feedback: () => sampleFeedback,
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 export const Liked: Story = {
@@ -72,7 +72,7 @@ export const Liked: Story = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 const likeResolvers = {
@@ -90,7 +90,7 @@ export const Like: Story = {
     novaEnvironment: {
       resolvers: likeResolvers,
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+  } satisfies NovaParameters,
   play: async (context) => {
     const container = within(context.canvasElement);
     const likeButton = await container.findByRole("button", { name: "Like" });
@@ -117,7 +117,7 @@ export const ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError
       novaEnvironment: {
         enableQueuedMockResolvers: false,
       },
-    } satisfies WithNovaEnvironment<FeedbackStoryQuery, TypeMap>,
+    } satisfies NovaParameters,
     play: async (context) => {
       const {
         graphql: { mock },

--- a/packages/examples/src/relay/Feedback/Feedback.test.tsx
+++ b/packages/examples/src/relay/Feedback/Feedback.test.tsx
@@ -7,8 +7,10 @@ import { executePlayFunction } from "../../testing-utils/executePlayFunction";
 import { prepareStoryContextForTest } from "@nova/react-test-utils/relay";
 import type { NovaEventing, EventWrapper } from "@nova/types";
 
-const { ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError, Primary } =
-  composeStories(stories);
+const {
+  ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError,
+  Primary,
+} = composeStories(stories);
 
 const bubbleMock = jest.fn<NovaEventing, [EventWrapper]>();
 const generateEventMock = jest.fn<NovaEventing, [EventWrapper]>();

--- a/packages/examples/src/relay/Feedback/Feedback.tsx
+++ b/packages/examples/src/relay/Feedback/Feedback.tsx
@@ -24,18 +24,16 @@ export const Feedback_feedbackFragment = graphql`
 export const FeedbackComponent = (props: Props) => {
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const feedback = useFragment(Feedback_feedbackFragment, props.feedback);
-  const [like, isPending] = useMutation<FeedbackComponent_LikeMutation>(
-    graphql`
-      mutation FeedbackComponent_LikeMutation($input: FeedbackLikeInput!) {
-        feedbackLike(input: $input) {
-          feedback {
-            id
-            doesViewerLike
-          }
+  const [like, isPending] = useMutation<FeedbackComponent_LikeMutation>(graphql`
+    mutation FeedbackComponent_LikeMutation($input: FeedbackLikeInput!) {
+      feedbackLike(input: $input) {
+        feedback {
+          id
+          doesViewerLike
         }
       }
-    `,
-  );
+    }
+  `);
 
   const onDeleteFeedback = useOnDeleteFeedback(
     feedback.id,

--- a/packages/examples/src/relay/Feedback/FeedbackContainer.stories.ts
+++ b/packages/examples/src/relay/Feedback/FeedbackContainer.stories.ts
@@ -11,9 +11,9 @@ import {
 } from "@nova/react-test-utils/relay";
 import type { TypeMap } from "../../__generated__/schema.all.interface";
 import { FeedbackContainer } from "./FeedbackContainer";
-import { getSchema } from "../../testing-utils/getSchema";
+import { schema } from "../../testing-utils/schema";
 
-const schema = getSchema();
+type NovaParameters = WithNovaEnvironment<UnknownOperation, TypeMap>;
 
 const MockPayloadGenerator = new PayloadGenerator(schema);
 
@@ -34,7 +34,7 @@ export const Primary: Story = {
         Feedback: () => sampleFeedback,
       },
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 export const Liked: Story = {
@@ -47,7 +47,7 @@ export const Liked: Story = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 const likeResolvers = {
@@ -65,7 +65,7 @@ export const Like: Story = {
     novaEnvironment: {
       resolvers: likeResolvers,
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
   play: async (context) => {
     const container = within(context.canvasElement);
     const likeButton = await container.findByRole("button", { name: "Like" });
@@ -89,7 +89,7 @@ export const LikeFailure: Story = {
     novaEnvironment: {
       enableQueuedMockResolvers: false,
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
   play: async (context) => {
     const container = within(context.canvasElement);
     const {
@@ -131,7 +131,7 @@ export const QueryFailure: Story = {
     novaEnvironment: {
       enableQueuedMockResolvers: false,
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
   play: async (context) => {
     const {
       graphql: { mock },
@@ -149,7 +149,7 @@ export const Loading: Story = {
     novaEnvironment: {
       enableQueuedMockResolvers: false,
     },
-  } satisfies WithNovaEnvironment<UnknownOperation, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 const sampleFeedback = {

--- a/packages/examples/src/relay/pure-relay/Feedback.stories.tsx
+++ b/packages/examples/src/relay/pure-relay/Feedback.stories.tsx
@@ -14,12 +14,12 @@ import { userEvent, waitFor, within, expect } from "@storybook/test";
 import type { TypeMap } from "../../__generated__/schema.all.interface";
 import { FeedbackComponent } from "./Feedback";
 import type { FeedbackStoryRelayQuery } from "./__generated__/FeedbackStoryRelayQuery.graphql";
-import { getSchema } from "../../testing-utils/getSchema";
+import { schema } from "../../testing-utils/schema";
 import * as React from "react";
 import type { events } from "../../events/events";
 import { RecordSource, Store } from "relay-runtime";
 
-const schema = getSchema();
+type NovaParameters = WithNovaEnvironment<FeedbackStoryRelayQuery, TypeMap>;
 
 const novaDecorator = getNovaDecorator(schema, {
   getEnvironmentOptions: () => ({
@@ -69,7 +69,7 @@ const meta = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryRelayQuery, TypeMap>,
+  } satisfies NovaParameters,
 } satisfies Meta<typeof FeedbackComponent>;
 
 export default meta;
@@ -84,7 +84,7 @@ export const Primary: Story = {
         Feedback: () => sampleFeedback,
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryRelayQuery, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 export const Liked: Story = {
@@ -97,7 +97,7 @@ export const Liked: Story = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryRelayQuery, TypeMap>,
+  } satisfies NovaParameters,
 };
 
 const likeResolvers = {
@@ -137,7 +137,7 @@ export const ArtificialFailureToShowcaseDecoratorBehaviorInCaseOfADevCausedError
       novaEnvironment: {
         enableQueuedMockResolvers: false,
       },
-    } satisfies WithNovaEnvironment<FeedbackStoryRelayQuery, TypeMap>,
+    } satisfies NovaParameters,
     play: async (context) => {
       const {
         graphql: { mock },
@@ -155,7 +155,7 @@ export const LikeFailure: Story = {
     novaEnvironment: {
       enableQueuedMockResolvers: false,
     },
-  } satisfies WithNovaEnvironment<FeedbackStoryRelayQuery, TypeMap>,
+  } satisfies NovaParameters,
   play: async (context) => {
     const container = within(context.canvasElement);
     const {

--- a/packages/examples/src/relay/pure-relay/ViewDataOnly.stories.ts
+++ b/packages/examples/src/relay/pure-relay/ViewDataOnly.stories.ts
@@ -1,13 +1,9 @@
 import type { Meta } from "@storybook/react";
-import { getSchema } from "../../testing-utils/getSchema";
+import { schema } from "../../testing-utils/schema";
 import { graphql } from "react-relay";
 import {
   getNovaDecorator,
-  getNovaEnvironmentForStory,
   type WithNovaEnvironment,
-  EventingInterceptor,
-  getOperationName,
-  getOperationType,
   type StoryObjWithoutFragmentRefs,
 } from "@nova/react-test-utils/relay";
 import { MockPayloadGenerator } from "relay-test-utils";
@@ -15,7 +11,7 @@ import { ViewDataOnly } from "./ViewDataOnly";
 import type { TypeMap } from "../../__generated__/schema.all.interface";
 import type { ViewDataOnlyStoryRelayQuery } from "./__generated__/ViewDataOnlyStoryRelayQuery.graphql";
 
-const schema = getSchema();
+type NovaParameters = WithNovaEnvironment<ViewDataOnlyStoryRelayQuery, TypeMap>;
 
 const novaDecorator = getNovaDecorator(schema, {
   generateFunction: (operation, mockResolvers) => {
@@ -52,7 +48,7 @@ const meta = {
         }),
       },
     },
-  } satisfies WithNovaEnvironment<ViewDataOnlyStoryRelayQuery, TypeMap>,
+  } satisfies NovaParameters,
 } satisfies Meta<typeof ViewDataOnly>;
 
 export default meta;
@@ -72,6 +68,9 @@ export const ViewDataOnlyWithServerFieldSelected: Story = {
           serverField
         }
       `,
+      referenceEntries: {
+        viewData: (data) => data?.viewData,
+      },
     },
-  },
+  } satisfies NovaParameters,
 };

--- a/packages/examples/src/testing-utils/executePlayFunction.ts
+++ b/packages/examples/src/testing-utils/executePlayFunction.ts
@@ -1,8 +1,5 @@
 import type { ReactRenderer } from "@storybook/react";
-import type {
-  PlayFunctionContext,
-  ComposedStoryFn,
-} from "@storybook/types";
+import type { PlayFunctionContext, ComposedStoryFn } from "@storybook/types";
 import { act, waitFor } from "@testing-library/react/pure";
 
 type PlayFunctionThatReturnsPromise = (

--- a/packages/examples/src/testing-utils/schema.ts
+++ b/packages/examples/src/testing-utils/schema.ts
@@ -2,5 +2,5 @@ import { buildASTSchema } from "graphql";
 
 export const schema = buildASTSchema(
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  require("../../data/schema.graphql")
+  require("../../data/schema.graphql"),
 );

--- a/packages/examples/src/testing-utils/schema.ts
+++ b/packages/examples/src/testing-utils/schema.ts
@@ -1,5 +1,6 @@
 import { buildASTSchema } from "graphql";
 
-export const getSchema = () =>
+export const schema = buildASTSchema(
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  buildASTSchema(require("../../data/schema.graphql"));
+  require("../../data/schema.graphql")
+);

--- a/packages/nova-graphql-compiler/package.json
+++ b/packages/nova-graphql-compiler/package.json
@@ -1,38 +1,38 @@
 {
   "name": "@nova/graphql-compiler",
-  "license": "MIT",
   "version": "1.0.2",
-  "main": "./src/cli.js",
-  "scripts": {
-    "lint": "monorepo-scripts lint",
-    "test": "monorepo-scripts test",
-    "just": "monorepo-scripts"
-  },
-  "bin": {
-    "nova-graphql-compiler": "./src/cli.js"
-  },
-  "dependencies": {
-    "relay-runtime": "12.0.0",
-    "graphql": "^15.5.0",
-    "relay-compiler": "^12.0.0",
-    "relay-compiler-language-graphitation": "^0.8.2",
-    "yargs": "^16.2.0",
-    "typescript": "<5"
-  },
-  "devDependencies": {
-    "cross-spawn": "^7.0.0",
-    "monorepo-scripts": "*"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/nova-facade.git",
     "directory": "packages/nova-graphql-compiler"
   },
+  "license": "MIT",
   "sideEffects": false,
-  "access": "public",
   "exports": {
     ".": {
       "require": "./src/cli.js"
     }
-  }
+  },
+  "main": "./src/cli.js",
+  "bin": {
+    "nova-graphql-compiler": "./src/cli.js"
+  },
+  "scripts": {
+    "just": "monorepo-scripts",
+    "lint": "monorepo-scripts lint",
+    "test": "monorepo-scripts test"
+  },
+  "dependencies": {
+    "graphql": "^15.5.0",
+    "relay-compiler": "^12.0.0",
+    "relay-compiler-language-graphitation": "^0.8.2",
+    "relay-runtime": "12.0.0",
+    "typescript": "<5",
+    "yargs": "^16.2.0"
+  },
+  "devDependencies": {
+    "cross-spawn": "^7.0.0",
+    "monorepo-scripts": "*"
+  },
+  "access": "public"
 }

--- a/packages/nova-react-test-utils/package.json
+++ b/packages/nova-react-test-utils/package.json
@@ -1,63 +1,34 @@
 {
   "name": "@nova/react-test-utils",
-  "license": "MIT",
   "version": "6.2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/nova-facade.git",
+    "directory": "packages/nova-test-utils"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./src/relay/index.ts",
+      "require": "./lib/relay/index.js"
+    },
+    "./relay": {
+      "import": "./src/relay/index.ts",
+      "require": "./lib/relay/index.js"
+    },
+    "./apollo": {
+      "import": "./src/apollo/index.ts",
+      "require": "./lib/apollo/index.js"
+    }
+  },
   "main": "./src/relay/index.ts",
   "scripts": {
     "build": "monorepo-scripts build",
+    "just": "monorepo-scripts",
     "lint": "monorepo-scripts lint",
     "test": "monorepo-scripts test",
-    "types": "monorepo-scripts types",
-    "just": "monorepo-scripts"
-  },
-  "peerDependencies": {
-    "@storybook/addon-actions": ">7.6",
-    "@storybook/preview-api": ">7.6",
-    "@storybook/react": ">7.6",
-    "@storybook/types": ">7.6",
-    "react": "^17 || ^18",
-    "@apollo/client": "^3.4",
-    "@graphitation/apollo-react-relay-duct-tape": "^1.3.0",
-    "@graphitation/apollo-mock-client": "^0.11.9",
-    "react-relay": ">16",
-    "relay-runtime": ">16",
-    "relay-test-utils": ">16",
-    "@types/react-relay": ">16",
-    "@types/relay-test-utils": ">16"
-  },
-  "peerDependenciesMeta": {
-    "@apollo/client": {
-      "optional": true,
-      "reason": "This package is only required if you are using Apollo as your GraphQL client."
-    },
-    "@graphitation/apollo-react-relay-duct-tape": {
-      "optional": true,
-      "reason": "This package is only required if you are using Apollo as your GraphQL client."
-    },
-    "@graphitation/apollo-mock-client": {
-      "optional": true,
-      "reason": "This package is only required if you are using Apollo as your GraphQL client."
-    },
-    "react-relay": {
-      "optional": true,
-      "reason": "This package is only required if you are using Relay as your GraphQL client."
-    },
-    "relay-runtime": {
-      "optional": true,
-      "reason": "This package is only required if you are using Relay as your GraphQL client."
-    },
-    "relay-test-utils": {
-      "optional": true,
-      "reason": "This package is only required if you are using Relay as your GraphQL client."
-    },
-    "@types/react-relay": {
-      "optional": true,
-      "reason": "This package is only required if you are using Relay as your GraphQL client."
-    },
-    "@types/relay-test-utils": {
-      "optional": true,
-      "reason": "This package is only required if you are using Relay as your GraphQL client."
-    }
+    "types": "monorepo-scripts types"
   },
   "dependencies": {
     "@graphitation/graphql-js-operation-payload-generator": "^0.12.9",
@@ -74,8 +45,8 @@
   },
   "devDependencies": {
     "@apollo/client": "^3.4.15",
-    "@graphitation/apollo-react-relay-duct-tape": "^1.3.0",
     "@graphitation/apollo-mock-client": "^0.11.9",
+    "@graphitation/apollo-react-relay-duct-tape": "^1.3.0",
     "@storybook/addon-actions": "^8.4.5",
     "@storybook/preview-api": "^8.4.5",
     "@storybook/react": "^8.4.5",
@@ -83,40 +54,65 @@
     "@testing-library/react": "^15.0.0",
     "@types/jest": "^29.2.0",
     "@types/react-relay": "^16.0.0",
-    "@types/relay-test-utils": "^18.0.0",
     "@types/react-test-renderer": "^18.3.0",
+    "@types/relay-test-utils": "^18.0.0",
     "monorepo-scripts": "*",
     "react": "^18.3.1",
     "react-relay": "^18.0.0",
+    "react-test-renderer": "^18.3.1",
     "relay-runtime": "^18.0.0",
-    "relay-test-utils": "^18.0.0",
-    "react-test-renderer": "^18.3.1"
+    "relay-test-utils": "^18.0.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/nova-facade.git",
-    "directory": "packages/nova-test-utils"
+  "peerDependencies": {
+    "@apollo/client": "^3.4",
+    "@graphitation/apollo-mock-client": "^0.11.9",
+    "@graphitation/apollo-react-relay-duct-tape": "^1.3.0",
+    "@storybook/addon-actions": ">7.6",
+    "@storybook/preview-api": ">7.6",
+    "@storybook/react": ">7.6",
+    "@storybook/types": ">7.6",
+    "@types/react-relay": ">16",
+    "@types/relay-test-utils": ">16",
+    "react": "^17 || ^18",
+    "react-relay": ">16",
+    "relay-runtime": ">16",
+    "relay-test-utils": ">16"
   },
-  "sideEffects": false,
-  "access": "public",
-  "exports": {
-    ".": {
-      "import": "./src/relay/index.ts",
-      "require": "./lib/relay/index.js"
+  "peerDependenciesMeta": {
+    "@apollo/client": {
+      "optional": true,
+      "reason": "This package is only required if you are using Apollo as your GraphQL client."
     },
-    "./relay": {
-      "import": "./src/relay/index.ts",
-      "require": "./lib/relay/index.js"
+    "@graphitation/apollo-mock-client": {
+      "optional": true,
+      "reason": "This package is only required if you are using Apollo as your GraphQL client."
     },
-    "./apollo": {
-      "import": "./src/apollo/index.ts",
-      "require": "./lib/apollo/index.js"
+    "@graphitation/apollo-react-relay-duct-tape": {
+      "optional": true,
+      "reason": "This package is only required if you are using Apollo as your GraphQL client."
+    },
+    "@types/react-relay": {
+      "optional": true,
+      "reason": "This package is only required if you are using Relay as your GraphQL client."
+    },
+    "@types/relay-test-utils": {
+      "optional": true,
+      "reason": "This package is only required if you are using Relay as your GraphQL client."
+    },
+    "react-relay": {
+      "optional": true,
+      "reason": "This package is only required if you are using Relay as your GraphQL client."
+    },
+    "relay-runtime": {
+      "optional": true,
+      "reason": "This package is only required if you are using Relay as your GraphQL client."
+    },
+    "relay-test-utils": {
+      "optional": true,
+      "reason": "This package is only required if you are using Relay as your GraphQL client."
     }
   },
   "publishConfig": {
-    "main": "./lib/relay/index",
-    "types": "./lib/relay/index.d.ts",
-    "module": "./lib/relay/index.mjs",
     "exports": {
       ".": {
         "import": "./lib/relay/index.mjs",
@@ -133,6 +129,10 @@
         "require": "./lib/apollo/index.js",
         "types": "./lib/apollo/index.d.ts"
       }
-    }
-  }
+    },
+    "main": "./lib/relay/index",
+    "module": "./lib/relay/index.mjs",
+    "types": "./lib/relay/index.d.ts"
+  },
+  "access": "public"
 }

--- a/packages/nova-react-test-utils/src/apollo/nova-mock-environment.tsx
+++ b/packages/nova-react-test-utils/src/apollo/nova-mock-environment.tsx
@@ -16,7 +16,9 @@ type ApolloNovaGraphQL = NovaGraphQL & {
 export type NovaMockEnvironment<T extends TestingEnvironmentVariant = "test"> =
   GenericNovaMockEnvironment<T, ApolloNovaGraphQL> & { type: "apollo" };
 
-export const NovaMockEnvironmentProvider = <T extends TestingEnvironmentVariant = "test">({
+export const NovaMockEnvironmentProvider = <
+  T extends TestingEnvironmentVariant = "test",
+>({
   children,
   environment,
 }: React.PropsWithChildren<

--- a/packages/nova-react-test-utils/src/relay/nova-mock-environment.tsx
+++ b/packages/nova-react-test-utils/src/relay/nova-mock-environment.tsx
@@ -15,7 +15,9 @@ type RelayNovaGraphQL = NovaGraphQL & {
 export type NovaMockEnvironment<T extends TestingEnvironmentVariant = "test"> =
   GenericNovaMockEnvironment<T, RelayNovaGraphQL> & { type: "relay" };
 
-export const NovaMockEnvironmentProvider = <T extends TestingEnvironmentVariant = "test">({
+export const NovaMockEnvironmentProvider = <
+  T extends TestingEnvironmentVariant = "test",
+>({
   children,
   environment,
 }: React.PropsWithChildren<

--- a/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
+++ b/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
@@ -17,7 +17,7 @@ const useMutation: NovaGraphQL<ConcreteRequest>["useMutation"] = (document) => {
     ({ variables, optimisticResponse, onCompleted }) => {
       const relayCompatibleOptimisticResponse =
         typeof optimisticResponse === "object"
-          ? optimisticResponse ?? undefined
+          ? (optimisticResponse ?? undefined)
           : undefined;
 
       return new Promise((resolve, reject) => {

--- a/packages/nova-react-test-utils/src/relay/storybook-nova-decorator-relay.tsx
+++ b/packages/nova-react-test-utils/src/relay/storybook-nova-decorator-relay.tsx
@@ -31,8 +31,8 @@ type OverloadedReturnType<T> = T extends {
 }
   ? R
   : T extends (...args: any[]) => infer R
-  ? R
-  : any;
+    ? R
+    : any;
 
 type GraphitationGenerateArgs = Parameters<
   RelayMockPayloadGenerator["generate"]

--- a/packages/nova-react-test-utils/src/shared/storybook-nova-decorator-shared.tsx
+++ b/packages/nova-react-test-utils/src/shared/storybook-nova-decorator-shared.tsx
@@ -33,32 +33,31 @@ export type WithNovaEnvironment<
   TQuery extends OperationType = UnknownOperation,
   TypeMap extends DefaultMockResolvers = DefaultMockResolvers,
 > = {
-  novaEnvironment:
-    | (
-        | {
-            query: GraphQLTaggedNode | RelayGraphQLTaggedNode;
-            variables?: TQuery["variables"];
-            referenceEntries: Record<
-              string,
-              (queryResult: TQuery["response"]) => unknown
-            >;
-          }
-        | {
-            query?: never;
-            variables?: never;
-            referenceEntries?: never;
-          }
-      ) &
-        (
-          | {
-              enableQueuedMockResolvers?: true;
-              resolvers?: MockResolvers<TypeMap>;
-            }
-          | {
-              enableQueuedMockResolvers?: false;
-              resolvers?: never;
-            }
-        );
+  novaEnvironment: (
+    | {
+        query: GraphQLTaggedNode | RelayGraphQLTaggedNode;
+        variables?: TQuery["variables"];
+        referenceEntries: Record<
+          string,
+          (queryResult: TQuery["response"]) => unknown
+        >;
+      }
+    | {
+        query?: never;
+        variables?: never;
+        referenceEntries?: never;
+      }
+  ) &
+    (
+      | {
+          enableQueuedMockResolvers?: true;
+          resolvers?: MockResolvers<TypeMap>;
+        }
+      | {
+          enableQueuedMockResolvers?: false;
+          resolvers?: never;
+        }
+    );
 };
 
 type RendererProps = {

--- a/packages/nova-react-test-utils/src/shared/types.d-test.ts
+++ b/packages/nova-react-test-utils/src/shared/types.d-test.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 type Expect<T extends true> = T;
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
-  ? 1
-  : 2
-  ? true
-  : false;
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
 
 import type { StoryObj, Meta } from "@storybook/react";
 import type {

--- a/packages/nova-react/package.json
+++ b/packages/nova-react/package.json
@@ -1,19 +1,20 @@
 {
   "name": "@nova/react",
-  "license": "MIT",
   "version": "2.7.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/nova-facade.git",
+    "directory": "packages/nova-react"
+  },
+  "license": "MIT",
+  "sideEffects": false,
   "main": "./src/index.ts",
   "scripts": {
     "build": "monorepo-scripts build",
+    "just": "monorepo-scripts",
     "lint": "monorepo-scripts lint",
     "test": "monorepo-scripts test",
-    "types": "monorepo-scripts types",
-    "just": "monorepo-scripts"
-  },
-  "peerDependencies": {
-    "react": "^17.0.2 || ^18",
-    "@types/react": "^17.0.2 || ^18",
-    "@graphitation/graphql-js-tag": "^0.9.4"
+    "types": "monorepo-scripts types"
   },
   "dependencies": {
     "@nova/types": "^1.6.0",
@@ -31,23 +32,22 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/microsoft/nova-facade.git",
-    "directory": "packages/nova-react"
+  "peerDependencies": {
+    "@graphitation/graphql-js-tag": "^0.9.4",
+    "@types/react": "^17.0.2 || ^18",
+    "react": "^17.0.2 || ^18"
   },
-  "sideEffects": false,
-  "access": "public",
   "publishConfig": {
-    "main": "./lib/index",
-    "types": "./lib/index.d.ts",
-    "module": "./lib/index.mjs",
     "exports": {
       ".": {
         "types": "./lib/index.d.ts",
         "import": "./lib/index.mjs",
         "require": "./lib/index.js"
       }
-    }
-  }
+    },
+    "main": "./lib/index",
+    "module": "./lib/index.mjs",
+    "types": "./lib/index.d.ts"
+  },
+  "access": "public"
 }

--- a/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
+++ b/packages/nova-react/src/commanding/nova-centralized-commanding-provider.tsx
@@ -11,14 +11,15 @@ interface NovaCentralizedCommandingProviderProps {
   children?: React.ReactNode | undefined;
 }
 
-export const NovaCentralizedCommandingProvider: React.FunctionComponent<NovaCentralizedCommandingProviderProps> =
-  ({ children, commanding }) => {
-    return (
-      <NovaCommandingContext.Provider value={commanding}>
-        {children}
-      </NovaCommandingContext.Provider>
-    );
-  };
+export const NovaCentralizedCommandingProvider: React.FunctionComponent<
+  NovaCentralizedCommandingProviderProps
+> = ({ children, commanding }) => {
+  return (
+    <NovaCommandingContext.Provider value={commanding}>
+      {children}
+    </NovaCommandingContext.Provider>
+  );
+};
 NovaCentralizedCommandingProvider.displayName =
   "NovaCentralizedCommandingProvider";
 

--- a/packages/nova-react/src/graphql/nova-graphql-provider.tsx
+++ b/packages/nova-react/src/graphql/nova-graphql-provider.tsx
@@ -10,14 +10,15 @@ interface NovaGraphQLProviderProps {
   children?: React.ReactNode | undefined;
 }
 
-export const NovaGraphQLProvider: React.FunctionComponent<NovaGraphQLProviderProps> =
-  ({ children, graphql }) => {
-    return (
-      <NovaGraphQLContext.Provider value={graphql}>
-        {children}
-      </NovaGraphQLContext.Provider>
-    );
-  };
+export const NovaGraphQLProvider: React.FunctionComponent<
+  NovaGraphQLProviderProps
+> = ({ children, graphql }) => {
+  return (
+    <NovaGraphQLContext.Provider value={graphql}>
+      {children}
+    </NovaGraphQLContext.Provider>
+  );
+};
 NovaGraphQLProvider.displayName = "NovaGraphQLProvider";
 
 export const useNovaGraphQL = (): NovaGraphQL => {

--- a/packages/nova-react/src/graphql/types.ts
+++ b/packages/nova-react/src/graphql/types.ts
@@ -35,9 +35,8 @@ export type FragmentRefs<Refs extends string> = {
 };
 
 // This is a utility type for converting from a data type to a fragment reference that will resolve to that data type.
-export type FragmentRef<Fragment> = Fragment extends _RefType<infer U>
-  ? _FragmentRefs<U>
-  : never;
+export type FragmentRef<Fragment> =
+  Fragment extends _RefType<infer U> ? _FragmentRefs<U> : never;
 
 /**
  * react-relay DT

--- a/packages/nova-types/package.json
+++ b/packages/nova-types/package.json
@@ -1,35 +1,35 @@
 {
   "name": "@nova/types",
-  "license": "MIT",
   "version": "1.6.0",
-  "main": "./src/index.ts",
-  "scripts": {
-    "build": "monorepo-scripts build",
-    "lint": "monorepo-scripts lint",
-    "types": "monorepo-scripts types",
-    "just": "monorepo-scripts"
-  },
-  "devDependencies": {
-    "@types/jest": "^29.2.0",
-    "monorepo-scripts": "*"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/nova-facade.git",
     "directory": "packages/nova-types"
   },
+  "license": "MIT",
   "sideEffects": false,
-  "access": "public",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "monorepo-scripts build",
+    "just": "monorepo-scripts",
+    "lint": "monorepo-scripts lint",
+    "types": "monorepo-scripts types"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.2.0",
+    "monorepo-scripts": "*"
+  },
   "publishConfig": {
-    "main": "./lib/index",
-    "types": "./lib/index.d.ts",
-    "module": "./lib/index.mjs",
     "exports": {
       ".": {
         "types": "./lib/index.d.ts",
         "import": "./lib/index.mjs",
         "require": "./lib/index.js"
       }
-    }
-  }
+    },
+    "main": "./lib/index",
+    "module": "./lib/index.mjs",
+    "types": "./lib/index.d.ts"
+  },
+  "access": "public"
 }

--- a/packages/nova-types/src/nova-localization.ts
+++ b/packages/nova-types/src/nova-localization.ts
@@ -27,11 +27,12 @@ export type StringWithPlaceholders<T extends Record<string, string | number>> =
  * Extract the placeholders from a localized string.
  * Guarantees that the placeholder object is not empty.
  */
-export type Placeholders<T> = T extends StringWithPlaceholders<infer P>
-  ? keyof P extends never // Make sure that the placeholder object is not empty
-    ? never
-    : P
-  : never;
+export type Placeholders<T> =
+  T extends StringWithPlaceholders<infer P>
+    ? keyof P extends never // Make sure that the placeholder object is not empty
+      ? never
+      : P
+    : never;
 
 type UseFormat = () => (
   localizedStringFromGraphQL: unknown,

--- a/scripts/config/jest.setup.ts
+++ b/scripts/config/jest.setup.ts
@@ -3,4 +3,3 @@ import { configure } from "@testing-library/react/pure";
 configure({
   reactStrictMode: true,
 });
-

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,9 +1,9 @@
 {
   "name": "monorepo-scripts",
   "version": "1.0.0",
-  "main": "index.js",
-  "license": "MIT",
   "private": true,
+  "license": "MIT",
+  "main": "index.js",
   "bin": {
     "monorepo-scripts": "bin/monorepo-scripts.js"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
-    "noPropertyAccessFromIndexSignature": true,
+    "noPropertyAccessFromIndexSignature": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,6 +1689,11 @@
     tslib "^2.5.0"
     webcrypto-core "^1.7.7"
 
+"@pkgr/core@^0.1.0":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.2.tgz#1cf95080bb7072fafaa3cb13b442fab4695c3893"
+  integrity sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==
+
 "@repeaterjs/repeater@3.0.4", "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@repeaterjs/repeater/-/repeater-3.0.4.tgz#a04d63f4d1bf5540a41b01a921c9a7fddc3bd1ca"
@@ -3928,10 +3933,20 @@ detect-indent@^6.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
+detect-indent@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-7.0.1.tgz#cbb060a12842b9c4d333f1cac4aa4da1bb66bc25"
+  integrity sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-newline@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-4.0.1.tgz#fcefdb5713e1fb8cb2839b8b6ee22e6716ab8f23"
+  integrity sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==
 
 diff-match-patch@1.0.5:
   version "1.0.5"
@@ -4517,6 +4532,11 @@ fbjs@^3.0.0, fbjs@^3.0.2:
     setimmediate "^1.0.5"
     ua-parser-js "^1.0.35"
 
+fdir@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
+  integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
+
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -4702,10 +4722,20 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stdin@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-9.0.0.tgz#3983ff82e03d56f1b2ea0d3e60325f39d703a575"
+  integrity sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==
+
 get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+git-hooks-list@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/git-hooks-list/-/git-hooks-list-3.2.0.tgz#ffe5d5895e29d24f930f9a98dd604b7e407d2f5f"
+  integrity sha512-ZHG9a1gEhUMX1TvGrLdyWb9kDopCBbTnI8z4JgRMYxsijWipgjSEYoPWqBuIB0DnRnvqlQSEeVmzpeuPm7NdFQ==
 
 git-up@^7.0.0:
   version "7.0.0"
@@ -5219,6 +5249,11 @@ is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-plain-obj@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
 is-plain-object@^2.0.4:
   version "2.0.4"
@@ -5968,10 +6003,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lage@2.7.15:
-  version "2.7.15"
-  resolved "https://registry.yarnpkg.com/lage/-/lage-2.7.15.tgz#966d16880954221fe91e959fadda83936b73c249"
-  integrity sha512-50+L6cSpCJOvLNi2VLoQuDU/8ncmXDHty02PKJveVzBA2BiQAwx/VdJw4BAdGflEUM7M/mkn86LDMuf9PHUxZQ==
+lage@2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/lage/-/lage-2.14.0.tgz#025d1db7b1271cb71d95658343340069dd705ea7"
+  integrity sha512-MgsFzOUhSVbWWHks/FBtovlvn/1rKzFERjzVJwX8nhpRuOLA0MsYpJGUrwb3oM4Hlx97+c0EOtCMEHMDZtXVmA==
   dependencies:
     glob-hasher "^1.4.2"
   optionalDependencies:
@@ -6648,6 +6683,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
 pirates@^4.0.4:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
@@ -6722,10 +6762,18 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.8.1:
-  version "2.8.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.7.tgz#bb79fc8729308549d28fe3a98fce73d2c0656450"
-  integrity sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==
+prettier-plugin-packagejson@^2.5.0:
+  version "2.5.10"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.10.tgz#f47068d0aa12efcdddb802189d8adae874ba00e7"
+  integrity sha512-LUxATI5YsImIVSaaLJlJ3aE6wTD+nvots18U3GuQMJpUyClChaZlQrqx3dBnbhF20OnKWZyx8EgyZypQtBDtgQ==
+  dependencies:
+    sort-package-json "2.15.1"
+    synckit "0.9.2"
+
+prettier@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.3.tgz#4fc2ce0d657e7a02e602549f053b239cb7dfe1b5"
+  integrity sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==
 
 pretty-error@^4.0.0:
   version "4.0.0"
@@ -7255,10 +7303,10 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.2, semver@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+semver@^7.0.0, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3:
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 semver@~7.3.0:
   version "7.3.8"
@@ -7384,6 +7432,25 @@ snake-case@^3.0.4:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
+
+sort-object-keys@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.3.tgz#bff833fe85cab147b34742e45863453c1e190b45"
+  integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
+
+sort-package-json@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-2.15.1.tgz#e5a035fad7da277b1947b9eecc93ea09c1c2526e"
+  integrity sha512-9x9+o8krTT2saA9liI4BljNjwAbvUnWf11Wq+i/iZt8nl2UGYnf3TH5uBydE7VALmP7AGwlfszuEeL8BDyb0YA==
+  dependencies:
+    detect-indent "^7.0.1"
+    detect-newline "^4.0.0"
+    get-stdin "^9.0.0"
+    git-hooks-list "^3.0.0"
+    is-plain-obj "^4.1.0"
+    semver "^7.6.0"
+    sort-object-keys "^1.1.3"
+    tinyglobby "^0.2.9"
 
 source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
@@ -7572,6 +7639,14 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+synckit@0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.9.2.tgz#a3a935eca7922d48b9e7d6c61822ee6c3ae4ec62"
+  integrity sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==
+  dependencies:
+    "@pkgr/core" "^0.1.0"
+    tslib "^2.6.2"
+
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
@@ -7626,6 +7701,14 @@ tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
+tinyglobby@^0.2.9:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.12.tgz#ac941a42e0c5773bd0b5d08f32de82e74a1a61b5"
+  integrity sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==
+  dependencies:
+    fdir "^6.4.3"
+    picomatch "^4.0.2"
 
 tinyrainbow@^1.2.0:
   version "1.2.0"
@@ -7760,10 +7843,10 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
-  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@~2.5.0:
   version "2.5.0"


### PR DESCRIPTION
In scope of this PR we:
* bump prettier
* bump lage
* add `prettier-plugin-packagejson`
* prettify all files
* extract shared `NovaParams` type in stories
* change schema to be computed once only