### PR TITLE
fix: bump TS and fix compatibility in 1JS

### DIFF
--- a/change/@nova-examples-a8a23456-2e26-4259-9c9d-78a2c0893f42.json
+++ b/change/@nova-examples-a8a23456-2e26-4259-9c9d-78a2c0893f42.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bump TS and fix compatibility with 1js",
+  "packageName": "@nova/examples",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-react-test-utils-f60f28a3-271f-4091-9f3b-966b95b74ad2.json
+++ b/change/@nova-react-test-utils-f60f28a3-271f-4091-9f3b-966b95b74ad2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bump TS and fix compatibility with 1js",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -59,7 +59,7 @@
     "relay-compiler": "^18.0.0",
     "relay-test-utils": "^18.0.0",
     "storybook": "^8.6.11",
-    "typescript": "^5.6.0",
+    "typescript": "^5.8.0",
     "vite": "^6.2.0",
     "vite-plugin-graphql-loader": "^4.0.0",
     "vite-plugin-relay": "^2.1.0",

--- a/packages/nova-react-test-utils/src/shared/storybook-nova-decorator-shared.tsx
+++ b/packages/nova-react-test-utils/src/shared/storybook-nova-decorator-shared.tsx
@@ -91,9 +91,9 @@ const Renderer: React.FC<RendererProps> = ({
       ([key, getValue]) => [key, getValue(data)] as const,
     );
     Object.assign(context.args, Object.fromEntries(entries));
-    return <>{getStory(context)}</>;
+    return <>{getStory(context) as React.ReactNode}</>;
   } else {
-    return <>{getStory(context)}</>;
+    return <>{getStory(context) as React.ReactNode}</>;
   }
 };
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,6 +23,6 @@
     "just-scripts": "^2.1.0",
     "ts-jest": "^29.2.0",
     "ts-node": "^10.4.0",
-    "typescript": "^5.6.0"
+    "typescript": "^5.8.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7423,10 +7423,10 @@ typescript@<5, typescript@>=4.2.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@^5.6.0:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
+typescript@^5.8.0:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 ua-parser-js@^1.0.35:
   version "1.0.38"


### PR DESCRIPTION
1JS bumped to TS 5.8 and they needed to create a patch to make testing utilities compatible with the new version of TypeScript. In this PR we bump the TS in the repo and push patched changes