### PR TITLE
fix(nova-react-test-utils): throw an informative error when artifacts loader is missing

### DIFF
--- a/change/@nova-examples-c0e28e10-db82-44dc-bd30-79896810d3f2.json
+++ b/change/@nova-examples-c0e28e10-db82-44dc-bd30-79896810d3f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add example for failure when artifact loader is missing",
+  "packageName": "@nova/examples",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-react-test-utils-1b789a4f-9d17-431c-a10e-002e53f6a681.json
+++ b/change/@nova-react-test-utils-1b789a4f-9d17-431c-a10e-002e53f6a681.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "throw an informative error message when artifact loader is missing",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/examples/src/relay/Feedback/Feedback.stories.tsx
+++ b/packages/examples/src/relay/Feedback/Feedback.stories.tsx
@@ -1,4 +1,4 @@
-import { graphql } from "react-relay";
+import { graphql } from "@nova/react";
 import {
   getNovaDecorator,
   getNovaEnvironmentForStory,

--- a/packages/examples/src/relay/Feedback/Feedback.test.error.tsx
+++ b/packages/examples/src/relay/Feedback/Feedback.test.error.tsx
@@ -24,7 +24,7 @@ describe("Feedback", () => {
     });
     const call = mockOnError.mock.calls[0];
     expect(call[0].message).toBe(
-      "Failed to load GraphQL artifact, got raw document instead. Make sure you have configured a loader (e.g., webpack loader, swc plugin) for working with compiled artifacts. Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#artifacts-loader, for more information.",
+      "Failed to load GraphQL artifact, got raw document instead. Make sure you have configured a loader (e.g., webpack loader, swc plugin) for working with compiled artifacts. Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#prerequisites, for more information.",
     );
   });
 });

--- a/packages/examples/src/relay/Feedback/Feedback.test.error.tsx
+++ b/packages/examples/src/relay/Feedback/Feedback.test.error.tsx
@@ -1,0 +1,30 @@
+import { expect, it, describe, vi } from "vitest";
+import { composeStory } from "@storybook/react";
+import * as stories from "./Feedback.stories";
+import { render } from "vitest-browser-react";
+import * as React from "react";
+
+const mockOnError = vi.fn<(e: Error) => void>();
+
+const Primary = composeStory(stories.Primary, {
+  ...stories.default,
+  parameters: {
+    ...stories.default.parameters,
+    errorBoundary: {
+      onError: mockOnError,
+    },
+  },
+});
+
+describe("Feedback", () => {
+  it("throws an error when artifact loader is not configured", async () => {
+    render(<Primary />);
+    await vi.waitFor(() => {
+      expect(mockOnError).toHaveBeenCalledTimes(1);
+    });
+    const call = mockOnError.mock.calls[0];
+    expect(call[0].message).toBe(
+      "Failed to load GraphQL artifact, got raw document instead. Make sure you have configured a loader (e.g., webpack loader, swc plugin) for working with compiled artifacts. Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#artifacts-loader, for more information.",
+    );
+  });
+});

--- a/packages/examples/src/relay/pure-relay/extensions/ViewDataOnly.stories.ts
+++ b/packages/examples/src/relay/pure-relay/extensions/ViewDataOnly.stories.ts
@@ -73,7 +73,7 @@ export const ViewDataOnlyStory: Story = {
     });
     const call = mockOnError.mock.calls[0];
     expect(call[0].message).toBe(
-      "Client only queries are not supported in nova-react-test-utils, please add at least a single server field, otherwise mock resolvers won't be called. Addtionally if you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension. Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#pure-relay-or-nova-with-relay-how-can-i-make-sure-the-mock-data-is-generated-for-client-extensions",
+      "Client only queries are not supported in nova-react-test-utils, please add at least a single server field, otherwise mock resolvers won't be called. Additionally if you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension. Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#pure-relay-or-nova-with-relay-how-can-i-make-sure-the-mock-data-is-generated-for-client-extensions",
     );
   },
 };

--- a/packages/examples/vitest.config.ts
+++ b/packages/examples/vitest.config.ts
@@ -6,7 +6,7 @@ import {
   mergeConfig,
 } from "vitest/config";
 import { storybookTest } from "@storybook/experimental-addon-test/vitest-plugin";
-import { plugins } from "./vitest.plugins";
+import { plugins, pluginsWithoutRelay } from "./vitest.plugins";
 import defaultConfig from "../../scripts/config/vitest.config";
 
 const dirname =
@@ -19,7 +19,29 @@ export default defineConfig({
     workspace: [
       {
         plugins: [...plugins],
-        test: mergeConfig(defaultConfig, {})["test"],
+        test: mergeConfig(defaultConfig, {
+          test: {
+            setupFiles: [".storybook/vitest.setup.ts"],
+          },
+        })["test"],
+      },
+      {
+        plugins: [...pluginsWithoutRelay],
+        test: {
+          name: "expectedErrors",
+          include: ["src/**/*.test.error.{ts,tsx}"],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: "playwright",
+            instances: [
+              {
+                browser: "chromium",
+              },
+            ],
+          },
+          setupFiles: [".storybook/vitest.setup.ts"],
+        },
       },
       {
         plugins: [

--- a/packages/examples/vitest.plugins.ts
+++ b/packages/examples/vitest.plugins.ts
@@ -17,3 +17,5 @@ export const plugins = [
   }),
   graphqlLoader(),
 ];
+
+export const pluginsWithoutRelay = [react(), graphqlLoader()];

--- a/packages/nova-react-test-utils/README.md
+++ b/packages/nova-react-test-utils/README.md
@@ -6,6 +6,10 @@ This package provides test utilities for components written with the React speci
 
 The utilities provided by this package should be used to test [apollo-react-relay-duct-tape](https://github.com/microsoft/graphitation/tree/main/packages/apollo-react-relay-duct-tape) or [react-relay](https://github.com/facebook/relay/tree/main/packages/react-relay) based components. Two variants of each utility and decorator are exposed under both `@nova/react-test-utils/apollo` and `@nova/react-test-utils/relay`, which should be picked based on which GraphQL runtime you want your tests and storybooks to use. If importing directly from `@nova/react-test-utils`, Relay variants will be imported by default.
 
+## Prerequisites
+
+If you are using GraphQL setup with artifact generation (like Relay or Apollo Duct Tape with `--emitDocuments`), you need to make sure that artifacts loader is setup for stories/tests. Depending on the tool, you can use [@graphitation/embedded-document-artefact-loader](@graphitation/embedded-document-artefact-loader) or [@swc/plugin-relay](https://www.npmjs.com/package/@swc/plugin-relay) for storybook. For unit tests, [examples](../examples/vitest.plugins.ts) contains a usage with vitest plugin and for jest you should rely on [babel-plugin-relay](https://www.npmjs.com/package/babel-plugin-relay) or [@graphitation/embedded-document-artefact-loader](https://github.com/microsoft/graphitation/tree/main/packages/embedded-document-artefact-loader#jest).
+
 ## Unit tests
 
 To leverage the power of mentioned packages inside your unit tests, you need to wrap the tested component with `NovaMockEnvironmentProvider`:

--- a/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
+++ b/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
@@ -42,16 +42,28 @@ const useMutation: NovaGraphQL<ConcreteRequest>["useMutation"] = (document) => {
   ];
 };
 
+const isGraphqlArtifact = (document: ConcreteRequest): boolean => {
+  // This happens when artifact loader is not configured, then document is of type {graphql.DocumentNode}
+  // and doesn't have params property
+  return !!document.params;
+};
+
 export const novaGraphql: Required<NovaGraphQL<ConcreteRequest>> = {
   useLazyLoadQuery: (
     document: ConcreteRequest,
     variables: Variables,
     options,
   ) => {
+    if (!isGraphqlArtifact(document)) {
+      throw new Error(
+        "Failed to load GraphQL artifact, got raw document instead. Make sure you have configured a loader (e.g., webpack loader, swc plugin) for working with compiled artifacts." +
+          " Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#artifacts-loader, for more information.",
+      );
+    }
     if (isClientOnlyQuery(document)) {
       throw new Error(
         "Client only queries are not supported in nova-react-test-utils, please add at least a single server field, otherwise mock resolvers won't be called." +
-          " Addtionally if you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension." +
+          " Additionally if you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension." +
           " Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#pure-relay-or-nova-with-relay-how-can-i-make-sure-the-mock-data-is-generated-for-client-extensions",
       );
     }
@@ -71,8 +83,7 @@ const isClientOnlyQuery = (document: ConcreteRequest) => {
   const queryText = document.params.text;
 
   const areAllSelectionsOnClientExtensions = document.fragment.selections.every(
-    (selection) =>
-      selection.kind === "ClientExtension" 
+    (selection) => selection.kind === "ClientExtension",
   );
 
   return queryText === null && areAllSelectionsOnClientExtensions;

--- a/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
+++ b/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
@@ -57,7 +57,7 @@ export const novaGraphql: Required<NovaGraphQL<ConcreteRequest>> = {
     if (!isGraphqlArtifact(document)) {
       throw new Error(
         "Failed to load GraphQL artifact, got raw document instead. Make sure you have configured a loader (e.g., webpack loader, swc plugin) for working with compiled artifacts." +
-          " Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#artifacts-loader, for more information.",
+          " Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#prerequisites, for more information.",
       );
     }
     if (isClientOnlyQuery(document)) {


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/f642e7db-45f1-451c-b3c7-b20767d9bb4f)

After:
![image](https://github.com/user-attachments/assets/cc7a642e-8fac-4e12-b04a-d6165c369a13)


Change done based on feedback from some confused 1JS devs. Added unit test which verifies this error flow