### PR TITLE
Add plural typings for usefragment

### DIFF
--- a/change/@nova-react-8f0ecf0d-0fe8-4af9-a35a-48acbbd52bf3.json
+++ b/change/@nova-react-8f0ecf0d-0fe8-4af9-a35a-48acbbd52bf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add plural typings for useFragment",
+  "packageName": "@nova/react",
+  "email": "alina.o.zaieva@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-react/src/graphql/hooks.test.tsx
+++ b/packages/nova-react/src/graphql/hooks.test.tsx
@@ -239,6 +239,38 @@ describe(useFragment, () => {
     // Workaround for TS complaining about unused variables
     void _, __, ___;
   });
+
+  it("returns an array when the fragment ref is an array", () => {
+    type SomeFragment$data = ReadonlyArray<{ someKey: string }>;
+    type SomeFragment$key = ReadonlyArray<{
+      readonly " $data"?: SomeFragment$data;
+      readonly " $fragmentRefs": FragmentRefs<"SomeFragment">;
+    }>;
+
+    const fragment = {} as unknown as GraphQLTaggedNode;
+    const opaqueFragmentRef = [{}] as unknown as SomeFragment$key;
+
+    const { result } = renderHook(
+      () => useFragment(fragment, opaqueFragmentRef),
+      {
+        wrapper: ({ children }) => (
+          <NovaGraphQLProvider graphql={{}}>{children}</NovaGraphQLProvider>
+        ),
+        initialProps: {
+          fragmentRef: opaqueFragmentRef,
+        },
+      },
+    );
+
+    type ExpectedReturnType = typeof result.current;
+
+    const _: IsNotNull<ExpectedReturnType> = true;
+    const __: IsNotUndefined<ExpectedReturnType> = true;
+    const ___: ExpectedReturnType = [{ someKey: "some-data" }];
+
+    // Workaround for TS complaining about unused variables
+    void _, __, ___;
+  });
 });
 
 describe(useRefetchableFragment, () => {

--- a/packages/nova-react/src/graphql/hooks.ts
+++ b/packages/nova-react/src/graphql/hooks.ts
@@ -9,6 +9,8 @@ import type {
   PaginationFn,
   RefetchFn,
   FetchPolicy,
+  ArrayKeyType,
+  ArrayKeyTypeData,
 } from "./types";
 
 /**
@@ -147,6 +149,14 @@ export function useFragment<TKey extends KeyType>(
   fragmentInput: GraphQLTaggedNode,
   fragmentRef: TKey | null | undefined,
 ): KeyTypeData<TKey> | null | undefined;
+export function useFragment<TKey extends ArrayKeyType>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: TKey,
+): ArrayKeyTypeData<TKey>;
+export function useFragment<TKey extends ArrayKeyType>(
+  fragmentInput: GraphQLTaggedNode,
+  fragmentRef: TKey | null | undefined,
+): ArrayKeyTypeData<TKey> | null | undefined;
 
 export function useFragment<TKey extends KeyType>(
   fragmentInput: GraphQLTaggedNode,

--- a/packages/nova-react/src/graphql/types.ts
+++ b/packages/nova-react/src/graphql/types.ts
@@ -61,7 +61,7 @@ export type KeyTypeData<
 
 export type ArrayKeyType<TData = unknown> = ReadonlyArray<KeyType<
   ReadonlyArray<TData>
-> | null>;
+> | null | undefined>;
 export type ArrayKeyTypeData<
   TKey extends ArrayKeyType<TData>,
   TData = unknown,


### PR DESCRIPTION
Relay's `useFragment` supports plural typings when `@relay(plural: true)` directive is set on the fragment. Typings in Nova currently do not allow this. See #147.

The PR adds two new signatures to `useFragment` hook definition, one for non-nullable array of refs and the other one for a nullable array. Nova already had `ArrayKeyType` and `ArrayKeyTypeData` utility types defined, they just were not used anywhere.

Only `useFragment` is updated since Relay does not support plural fragments for any other fragment hooks (e.g., `useRefetchableFragment`). 