### PR TITLE
fix(nova-react-test-utils): relax error on view data only queries

### DIFF
--- a/change/@nova-examples-5cb6aef4-c7d5-4af4-8706-3aea7326df71.json
+++ b/change/@nova-examples-5cb6aef4-c7d5-4af4-8706-3aea7326df71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update example to match new error",
+  "packageName": "@nova/examples",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@nova-react-test-utils-61f6d56b-3b82-42d2-b4b8-3c20edd76731.json
+++ b/change/@nova-react-test-utils-61f6d56b-3b82-42d2-b4b8-3c20edd76731.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "relax error on view data only queries",
+  "packageName": "@nova/react-test-utils",
+  "email": "Stanislaw.Wilczynski@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/examples/src/relay/pure-relay/extensions/ViewDataOnly.stories.ts
+++ b/packages/examples/src/relay/pure-relay/extensions/ViewDataOnly.stories.ts
@@ -17,6 +17,12 @@ type NovaParameters = WithNovaEnvironment<ViewDataOnlyStoryRelayQuery, TypeMap>;
 
 const mockOnError = fn<[Error]>();
 
+const originalConsoleWarn = console.warn;
+const consoleWarnMock = fn((...args) => {
+  originalConsoleWarn(...args);
+});
+console.warn = consoleWarnMock;
+
 const novaDecorator = getNovaDecorator(schema, {
   generateFunction: (operation, mockResolvers) => {
     const result = MockPayloadGenerator.generate(
@@ -73,7 +79,10 @@ export const ViewDataOnlyStory: Story = {
     });
     const call = mockOnError.mock.calls[0];
     expect(call[0].message).toBe(
-      "Client only queries are not supported in nova-react-test-utils, please add at least a single server field, otherwise mock resolvers won't be called. Additionally if you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension. Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#pure-relay-or-nova-with-relay-how-can-i-make-sure-the-mock-data-is-generated-for-client-extensions",
+      "Cannot read properties of null (reading 'viewDataField')",
+    );
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      "The ViewDataOnlyStoryRelayQuery query is a client-only query, which means mock resolvers won't get called. Please select at least one server field in the query to ensure that mock resolvers are called.",
     );
   },
 };

--- a/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
+++ b/packages/nova-react-test-utils/src/relay/nova-relay-graphql.ts
@@ -61,10 +61,11 @@ export const novaGraphql: Required<NovaGraphQL<ConcreteRequest>> = {
       );
     }
     if (isClientOnlyQuery(document)) {
-      throw new Error(
-        "Client only queries are not supported in nova-react-test-utils, please add at least a single server field, otherwise mock resolvers won't be called." +
-          " Additionally if you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension." +
-          " Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#pure-relay-or-nova-with-relay-how-can-i-make-sure-the-mock-data-is-generated-for-client-extensions",
+      console.warn(`The ${document.params.name} query is a client-only query, which means mock resolvers won't get called. Please select at least one server field in the query to ensure that mock resolvers are called.`);
+      console.warn(
+          ` If you want to test any queries with client extension, please use relay based payload generator over default one, as the default still doesn't support client extension. ` +
+          ` Check https://github.com/microsoft/nova-facade/tree/main/packages/nova-react-test-utils#pure-relay-or-nova-with-relay-how-can-i-make-sure-the-mock-data-is-generated-for-client-extensions ` +
+          ` If you have a nested client extensions only query, make sure to have a query with server field on top of your story which selects same client extensions to fill the cache.`,
       );
     }
     return {


### PR DESCRIPTION
In 1JS we have multiple instance of folks having nested view data queries and then the decorator blows up as it wasn't an expected scenario. One can still make it work by filling the store for that specific piece of view data in some other query but thrown error makes the DX pretty and requires import change to use relay directly. To make DX better but still give feedback to user we rely on console warnings instead,

Also with facebook/relay#4999 by @jakobkhansen we soon will be able to support client extensions properly