### PR TITLE
Add @nova/schema package

### DIFF
--- a/change/@nova-schema-dba179e9-3aaa-4ac8-82ba-d45c8cd2bd07.json
+++ b/change/@nova-schema-dba179e9-3aaa-4ac8-82ba-d45c8cd2bd07.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Create the package",
+  "packageName": "@nova/schema",
+  "email": "alina.o.zaieva@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/nova-schema/README.md
+++ b/packages/nova-schema/README.md
@@ -1,0 +1,5 @@
+# nova-schema
+
+The Nova Facade is a set of interfaces that represent the core framework dependencies of a data-backed UI component in a large application. This allows high value components to be written in a host agnostic fashion and used within any host that implements the Nova contracts.
+
+This Schema package contains the GraphQL schema definitions that help with declaring data dependencies of high value components.

--- a/packages/nova-schema/index.graphql
+++ b/packages/nova-schema/index.graphql
@@ -1,0 +1,33 @@
+input LocalizedStringPlaceholder {
+  """
+  The name of the placeholder (without curly braces).
+  """
+  name: String!
+
+  """
+  The description of the placeholder.
+  """
+  comment: String!
+}
+
+"""
+Marks a field as a localized string.
+
+See https://github.com/microsoft/nova-facade/tree/main/packages/nova-react#defining-a-localized-string
+"""
+directive @localizedString(
+  """
+  The text of the localized string. May contain placeholders in format `{placeholderName}`.
+  """
+  text: String!
+
+  """
+  The description of the localized string.
+  """
+  comment: String!
+
+  """
+  Descriptions of the placeholders used in the localized string.
+  """
+  placeholders: [LocalizedStringPlaceholder!]! = []
+) on FIELD_DEFINITION

--- a/packages/nova-schema/package.json
+++ b/packages/nova-schema/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@nova/schema",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/nova-facade.git",
+    "directory": "packages/nova-schema"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "access": "public"
+}


### PR DESCRIPTION
Nova defines extra pieces of SDL to allow high-value components to provide extra metadata as a part of their GraphQL schema. This new package will be used to host these SDL declarations, and can be used both for documentation purposes and for GraphQL tooling. 