### PR TITLE
chore: add engines field and bump node on CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
     "lage": "2.14.0",
     "prettier": "^3.5.0",
     "prettier-plugin-packagejson": "^2.5.0"
+  },
+  "engines": {
+    "node": ">=20.11.0",
+    "yarn": "^1.21.1"
   }
 }


### PR DESCRIPTION
In scope of this PR we bump node version on CI (from 18.x to 20.x as 18 is already after EOL and both 1JS and TMP are already on 22 and 20 respectively) and also add engines field to package json to inform devs about it.