### PR TITLE
fix(nova-react-test-utils): explicit export type of EventingInterceptorFn

### DIFF
--- a/packages/nova-react-test-utils/src/shared/eventing-interceptor.tsx
+++ b/packages/nova-react-test-utils/src/shared/eventing-interceptor.tsx
@@ -15,13 +15,19 @@ type EventMap<T extends EventCreatorMap> = {
   }) => Promise<undefined | EventWrapper>;
 };
 
+export type EventingInterceptorProps<T extends EventCreatorMap> = {
+  eventMap: EventMap<T>;
+  children: React.ReactNode;
+};
+
+export type EventingInterceptorFn = <T extends EventCreatorMap>(
+  props: EventingInterceptorProps<T>,
+) => React.ReactElement;
+
 export const EventingInterceptor = <T extends EventCreatorMap>({
   eventMap,
   children,
-}: {
-  eventMap: EventMap<T>;
-  children: React.ReactNode;
-}) => {
+}: EventingInterceptorProps<T>) => {
   const interceptor: EventInterceptor = (eventWrapper) => {
     const eventType = eventWrapper.event.type;
     const customEventHandler = eventMap[eventType];


### PR DESCRIPTION
The d.ts emitter failed when re-exporting a specialized EventingInterceptor:

  “The inferred type of 'EventingInterceptor' cannot be named without a reference to '../../../../<package>/node_modules/@nova/types/lib'. This is likely not portable. A type annotation is necessary.”

Root cause:

- Specializing the generic implementation with typeof suggestionCardEvents produces a function type that references upstream types only reachable via deep node_modules paths. The emitter cannot produce a portable module specifier for that inferred type.

### Summary

Fixes a TypeScript declaration emit error when re‑exporting a specialized `EventingInterceptor` from **nova-react-test-utils**.

### Problem
The d.ts emitter failed when re-exporting a specialized `EventingInterceptor`.

For:
```ts
import type { events as cardEvents } from "@repo/react-component-nova-events";
import {
  EventingInterceptor as GenericEventingInterceptor,
  type EventingInterceptorFn,
} from "nova-react-test-utils";

export const EventingInterceptor =
  GenericEventingInterceptor<
    SuggestionCardEventMap
  >;
```

It’s a .d.ts–emitter issue. Where exporting a value whose inferred
type, after we specialize the generic with `typeof cardEvents`, ends up
mentioning types that TypeScript can only refer to via a non‑portable path like
`../../../../<package>/node_modules/@nova/types/lib`. When TS tries to print
your package’s .d.ts, it can’t name that type with a stable module specifier, so
it asks you to add an explicit, portable annotation.

We get the error:
```
> The inferred type of 'EventingInterceptor' cannot be named without a reference to
`../../../../<package>/node_modules/@nova/types/lib`.
This is likely not portable. A type annotation is necessary.
```

This error often appears when a type is only reachable through a transitive package's `node_modules`.

### Solution
- Added a public generic type:
```ts
export type EventingInterceptorFn<T extends EventCreatorMap> =
  (props: EventingInterceptorProps<T>) => React.ReactElement;
```

So we get a monomorphic type when used like:

```
export const EventingInterceptor: EventingInterceptorFn<SuggestionCardEventMap> =
  GenericEventingInterceptor
```